### PR TITLE
Refactor: Centralize game logic and improve structure

### DIFF
--- a/lib/blocs/chess_bloc.dart
+++ b/lib/blocs/chess_bloc.dart
@@ -1,11 +1,16 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../models/chess_models.dart';
 import '../screens/game_screen.dart';
-import '../utils/chess_rules.dart';
+// import '../utils/chess_rules.dart'; // ChessRules will be used via GameLogicService
+import '../services/game_logic_service.dart';
 import 'chess_event.dart';
 
 class ChessBloc extends Bloc<ChessEvent, GameState> {
-  ChessBloc() : super(GameState.initial()) {
+  final GameLogicService _gameLogicService;
+
+  ChessBloc() 
+      : _gameLogicService = GameLogicService(),
+        super(GameState.initial()) {
     on<InitializeGame>(_onInitializeGame);
     on<SelectPiece>(_onSelectPiece);
     on<MovePiece>(_onMovePiece);
@@ -22,7 +27,7 @@ class ChessBloc extends Bloc<ChessEvent, GameState> {
 
   void _onInitializeGame(InitializeGame event, Emitter<GameState> emit) async {
     if (event.replayGame != null) {
-      // 初始化复盘状态
+      // Initialize replay state
       final initialState = await GameState.initialFromPrefs(
         hintMode: event.hintMode,
         isInteractive: event.isInteractive,
@@ -30,17 +35,21 @@ class ChessBloc extends Bloc<ChessEvent, GameState> {
         gameMode: event.gameMode,
       );
 
-      // 生成所有中间状态
+      // Generate all intermediate states
       final states = <GameState>[initialState];
       var currentState = initialState;
 
-      // 应用所有移动来生成中间状态
+      // Apply all moves to generate intermediate states using GameLogicService
       for (final move in event.replayGame!.moves) {
-        currentState = await _applyMove(currentState, move);
+        // Assuming applyMove in GameLogicService updates necessary state like history for replay.
+        // If applyMove is purely for board changes, this might need adjustment
+        // or a dedicated replay-move-application method in GameLogicService.
+        // For now, direct usage of applyMove as per current GameLogicService structure.
+        currentState = _gameLogicService.applyMove(currentState, move);
         states.add(currentState);
       }
 
-      // 正常复盘模式
+      // Normal replay mode
       emit(states[0].copyWith(
         moveHistory: event.replayGame!.moves,
         redoStates: states.sublist(1),
@@ -100,48 +109,6 @@ class ChessBloc extends Bloc<ChessEvent, GameState> {
     emit(initialState);
   }
 
-  Future<GameState> _applyMove(GameState state, ChessMove move) async {
-    // 创建新的棋盘状态
-    final newBoard = List<List<ChessPiece?>>.from(
-      state.board.map((row) => List<ChessPiece?>.from(row)),
-    );
-
-    // 移动棋子
-    newBoard[move.to.row][move.to.col] = move.piece;
-    newBoard[move.from.row][move.from.col] = null;
-
-    // 处理吃过路兵
-    if (move.isEnPassant) {
-      newBoard[move.from.row][move.to.col] = null;
-    }
-
-    // 处理王车易位
-    if (move.isCastling) {
-      final rookFromCol = move.from.col > move.to.col ? 0 : 7;
-      final rookToCol = move.from.col > move.to.col ? 3 : 5;
-      newBoard[move.from.row][rookToCol] = newBoard[move.from.row][rookFromCol];
-      newBoard[move.from.row][rookFromCol] = null;
-    }
-
-    // 处理升变
-    if (move.isPromotion && move.promotionType != null) {
-      newBoard[move.to.row][move.to.col] = ChessPiece(
-        type: move.promotionType!,
-        color: move.piece.color,
-      );
-    }
-
-    // 更新状态
-    return state.copyWith(
-      board: newBoard,
-      currentPlayer: state.currentPlayer == PieceColor.white ? PieceColor.black : PieceColor.white,
-      selectedPosition: null,
-      validMoves: const [],
-      moveHistory: List.from(state.moveHistory)..add(move),
-      lastMove: move,
-    );
-  }
-
   void _onSelectPiece(SelectPiece event, Emitter<GameState> emit) {
     // 如果棋盘不可交互或游戏已结束，不允许选择棋子
     if (!state.isInteractive || state.isCheckmate || state.isStalemate) {
@@ -161,564 +128,122 @@ class ChessBloc extends Bloc<ChessEvent, GameState> {
       return;
     }
 
+    // The existing logic for checking interactivity, game over state, and player turn
+    // is now part of _gameLogicService.getValidMovesForPiece.
+    // We directly call the service method.
+    final validMoves = _gameLogicService.getValidMovesForPiece(state, event.position);
+
+    // Check if the piece at event.position belongs to the current player.
+    // This check is also inside getValidMovesForPiece, which returns empty if not.
+    // If validMoves is empty, it implies either no valid moves or selection was invalid.
+    // The GameState's selectedPosition should only be updated if the selection was valid (i.e. a piece of current player was selected).
     final piece = state.board[event.position.row][event.position.col];
-
-    // 检查是否是当前玩家的棋子
-    if (piece?.color != state.currentPlayer) {
-      emit(state.copyWith(
-        selectedPosition: null,
-        validMoves: [],
-      ));
-      return;
+    if (piece != null && piece.color == state.currentPlayer) {
+        emit(state.copyWith(
+          selectedPosition: event.position, // Update selected position
+          validMoves: validMoves,
+        ));
+    } else {
+        // If piece is null or not current player's piece, treat as invalid selection.
+        // Clear previous selection and valid moves.
+        emit(state.copyWith(
+          selectedPosition: null,
+          validMoves: [],
+        ));
     }
-
-    final validMoves = ChessRules.getValidMoves(
-      state.board,
-      event.position,
-      hasKingMoved: state.hasKingMoved,
-      hasRookMoved: state.hasRookMoved,
-      lastPawnDoubleMoved: state.lastPawnDoubleMoved[piece?.color == PieceColor.white ? PieceColor.black : PieceColor.white],
-      lastPawnDoubleMovedNumber: state.lastPawnDoubleMovedNumber[piece?.color == PieceColor.white ? PieceColor.black : PieceColor.white],
-      currentMoveNumber: state.currentMoveNumber,
-    );
-
-    emit(state.copyWith(
-      selectedPosition: event.position,
-      validMoves: validMoves,
-    ));
   }
 
   void _onMovePiece(MovePiece event, Emitter<GameState> emit) {
-    if (state.selectedPosition == null) return;
-
-    final isValidMove = state.validMoves.any(
-      (pos) => pos.row == event.to.row && pos.col == event.to.col
-    );
-    if (!isValidMove) return;
-
-    final movingPiece = state.board[event.from.row][event.from.col]!;
-    final capturedPiece = state.board[event.to.row][event.to.col];
-    final newBoard = List<List<ChessPiece?>>.from(
-      state.board.map((row) => List<ChessPiece?>.from(row))
-    );
-
-    // 处理王车易位
-    if (_isCastlingMove(movingPiece, event)) {
-      _handleCastling(event, movingPiece, newBoard, emit);
-      return;
+    // selectedPosition should be event.from.
+    // The GameLogicService.handleMove now takes 'from' and 'to' positions.
+    // It also handles the validation of the move against the current valid moves.
+    if (state.selectedPosition == null || state.selectedPosition != event.from) {
+        // This case should ideally not happen if UI is driven by selectedPosition and validMoves.
+        // Or, it means a move was attempted without prior selection.
+        // For robustness, we can choose to ignore or handle as an error.
+        return; 
     }
-
-    // 记录双步移动的兵
-    Position? newLastPawnDoubleMoved;
-    if (_isPawnDoubleMove(movingPiece, event)) {
-      newLastPawnDoubleMoved = event.to;
-    }
-
-    // 处理吃过路兵
-    if (_isEnPassantMove(movingPiece, event, capturedPiece)) {
-      _handleEnPassant(event, movingPiece, newBoard, emit);
-      return;
-    }
-
-    // 处理兵的升变
-    if (_isPawnPromotion(movingPiece, event)) {
-      _handlePawnPromotion(event, movingPiece, newBoard, emit);
-      return;
-    }
-
-    // 执行常规移动
-    _handleRegularMove(event, movingPiece, capturedPiece, newBoard, newLastPawnDoubleMoved, emit);
-  }
-
-  bool _isCastlingMove(ChessPiece movingPiece, MovePiece event) {
-    return movingPiece.type == PieceType.king &&
-           (event.from.col - event.to.col).abs() == 2;
-  }
-
-  void _handleCastling(MovePiece event, ChessPiece movingPiece, List<List<ChessPiece?>> newBoard, Emitter<GameState> emit) {
-    final isKingside = event.to.col > event.from.col;
-    final rookFromCol = isKingside ? 7 : 0;
-    final rookToCol = isKingside ? 5 : 3;
-
-    newBoard[event.to.row][event.to.col] = movingPiece;
-    newBoard[event.from.row][event.from.col] = null;
-    newBoard[event.from.row][rookToCol] = newBoard[event.from.row][rookFromCol];
-    newBoard[event.from.row][rookFromCol] = null;
-
-    final newHasKingMoved = Map<PieceColor, bool>.from(state.hasKingMoved);
-    newHasKingMoved[movingPiece.color] = true;
-
-    final move = ChessMove(
-      from: event.from,
-      to: event.to,
-      piece: movingPiece,
-      isCastling: true,
-    );
-
-    String message = '${movingPiece.color == PieceColor.white ? "白方" : "黑方"}王从${_getPositionName(event.from)}进行${isKingside ? "王翼" : "后翼"}易位到${_getPositionName(event.to)}';
-
-    // 检查对手是否被将军或将死
-    final nextPlayer = state.currentPlayer == PieceColor.white ? PieceColor.black : PieceColor.white;
-    final isCheck = ChessRules.isInCheck(newBoard, nextPlayer);
-    final isCheckmate = isCheck && ChessRules.isCheckmate(
-      newBoard,
-      nextPlayer,
-      newHasKingMoved,
-      state.hasRookMoved,
-      state.lastPawnDoubleMoved,
-      state.lastPawnDoubleMovedNumber,
-      state.currentMoveNumber + 1,
-    );
-    final isStalemate = !isCheck && ChessRules.isStalemate(
-      newBoard,
-      nextPlayer,
-      newHasKingMoved,
-      state.hasRookMoved,
-      state.lastPawnDoubleMoved,
-      state.lastPawnDoubleMovedNumber,
-      state.currentMoveNumber + 1,
-    );
-
-    // 添加将军或将死的提示
-    if (isCheckmate) {
-      message += ' 将死！${state.currentPlayer == PieceColor.white ? "白方" : "黑方"}获胜！';
-    } else if (isCheck) {
-      message += ' 将军！';
-    } else if (isStalemate) {
-      message += ' 和棋！';
-    }
-
-    // 保存当前状态到撤销列表
-    final newUndoStates = List<GameState>.from(state.undoStates)..add(state);
-
-    emit(state.copyWith(
-      board: newBoard,
-      currentPlayer: nextPlayer,
-      selectedPosition: null,
-      validMoves: [],
-      hasKingMoved: newHasKingMoved,
-      currentMoveNumber: state.currentMoveNumber + 1,
-      moveHistory: [...state.moveHistory, move],
-      specialMoveMessage: message,
-      lastMove: move,
-      isCheck: isCheck,
-      isCheckmate: isCheckmate,
-      isStalemate: isStalemate,
-      undoStates: newUndoStates,
-      redoStates: [], // 清空重做列表
-    ));
-  }
-
-  bool _isPawnDoubleMove(ChessPiece movingPiece, MovePiece event) {
-    return movingPiece.type == PieceType.pawn &&
-           (event.from.row - event.to.row).abs() == 2;
-  }
-
-  bool _isEnPassantMove(ChessPiece movingPiece, MovePiece event, ChessPiece? capturedPiece) {
-    // 获取对手的双步兵记录
-    final opponentColor = movingPiece.color == PieceColor.white ? PieceColor.black : PieceColor.white;
-    final opponentLastPawnDoubleMoved = state.lastPawnDoubleMoved[opponentColor];
-    final opponentLastMoveNumber = state.lastPawnDoubleMovedNumber[opponentColor];
-
-    if (movingPiece.type != PieceType.pawn ||
-        opponentLastPawnDoubleMoved == null ||
-        event.from.col == event.to.col ||
-        opponentLastMoveNumber != state.currentMoveNumber - 1) {
-      return false;
-    }
-
-    // 检查是否是吃过路兵的位置
-    if (movingPiece.color == PieceColor.white) {
-      return event.from.row == 3 && // 白方兵在第5行
-             opponentLastPawnDoubleMoved.row == 3 && // 黑方兵在第5行
-             opponentLastPawnDoubleMoved.col == event.to.col && // 目标列与黑方兵相同
-             (event.from.col - event.to.col).abs() == 1; // 斜向移动一格
-    } else {
-      return event.from.row == 4 && // 黑方兵在第4行
-             opponentLastPawnDoubleMoved.row == 4 && // 白方兵在第4行
-             opponentLastPawnDoubleMoved.col == event.to.col && // 目标列与白方兵相同
-             (event.from.col - event.to.col).abs() == 1; // 斜向移动一格
-    }
-  }
-
-  void _handleEnPassant(MovePiece event, ChessPiece movingPiece, List<List<ChessPiece?>> newBoard, Emitter<GameState> emit) {
-    final opponentColor = movingPiece.color == PieceColor.white ? PieceColor.black : PieceColor.white;
-    final opponentLastPawnDoubleMoved = state.lastPawnDoubleMoved[opponentColor]!;
-
-    // 获取被吃的兵
-    final capturedPawn = state.board[opponentLastPawnDoubleMoved.row][opponentLastPawnDoubleMoved.col]!;
-
-    // 移除被吃的兵
-    newBoard[opponentLastPawnDoubleMoved.row][opponentLastPawnDoubleMoved.col] = null;
-
-    // 移动吃子的兵
-    newBoard[event.to.row][event.to.col] = movingPiece;
-    newBoard[event.from.row][event.from.col] = null;
-
-    final move = ChessMove(
-      from: event.from,
-      to: event.to,
-      piece: movingPiece,
-      capturedPiece: capturedPawn,
-      isEnPassant: true,
-    );
-
-    // 创建新的双步兵记录
-    final newLastPawnDoubleMoved = Map<PieceColor, Position?>.from(state.lastPawnDoubleMoved);
-    final newLastPawnDoubleMovedNumber = Map<PieceColor, int>.from(state.lastPawnDoubleMovedNumber);
-    newLastPawnDoubleMoved[opponentColor] = null;
-    newLastPawnDoubleMovedNumber[opponentColor] = -1;
-
-    String message = '${movingPiece.color == PieceColor.white ? "白方" : "黑方"}兵从${_getPositionName(event.from)}吃过路兵到${_getPositionName(event.to)}';
-
-    // 检查对手是否被将军或将死
-    final nextPlayer = state.currentPlayer == PieceColor.white ? PieceColor.black : PieceColor.white;
-    final isCheck = ChessRules.isInCheck(newBoard, nextPlayer);
-    final isCheckmate = isCheck && ChessRules.isCheckmate(
-      newBoard,
-      nextPlayer,
-      state.hasKingMoved,
-      state.hasRookMoved,
-      newLastPawnDoubleMoved,
-      newLastPawnDoubleMovedNumber,
-      state.currentMoveNumber + 1,
-    );
-    final isStalemate = !isCheck && ChessRules.isStalemate(
-      newBoard,
-      nextPlayer,
-      state.hasKingMoved,
-      state.hasRookMoved,
-      newLastPawnDoubleMoved,
-      newLastPawnDoubleMovedNumber,
-      state.currentMoveNumber + 1,
-    );
-
-    // 添加将军或将死的提示
-    if (isCheckmate) {
-      message += ' 将死！${state.currentPlayer == PieceColor.white ? "白方" : "黑方"}获胜！';
-    } else if (isCheck) {
-      message += ' 将军！';
-    } else if (isStalemate) {
-      message += ' 和棋！';
-    }
-
-    // 保存当前状态到撤销列表
-    final newUndoStates = List<GameState>.from(state.undoStates)..add(state);
-
-    emit(state.copyWith(
-      board: newBoard,
-      currentPlayer: nextPlayer,
-      selectedPosition: null,
-      validMoves: [],
-      lastPawnDoubleMoved: newLastPawnDoubleMoved,
-      lastPawnDoubleMovedNumber: newLastPawnDoubleMovedNumber,
-      currentMoveNumber: state.currentMoveNumber + 1,
-      moveHistory: [...state.moveHistory, move],
-      specialMoveMessage: message,
-      lastMove: move,
-      isCheck: isCheck,
-      isCheckmate: isCheckmate,
-      isStalemate: isStalemate,
-      undoStates: newUndoStates,
-      redoStates: [], // 清空重做列表
-    ));
-  }
-
-  bool _isPawnPromotion(ChessPiece movingPiece, MovePiece event) {
-    return movingPiece.type == PieceType.pawn &&
-           (event.to.row == 0 || event.to.row == 7);
-  }
-
-  void _handlePawnPromotion(MovePiece event, ChessPiece movingPiece, List<List<ChessPiece?>> newBoard, Emitter<GameState> emit) {
-    newBoard[event.to.row][event.to.col] = movingPiece;
-    newBoard[event.from.row][event.from.col] = null;
-
-    final move = ChessMove(
-      from: event.from,
-      to: event.to,
-      piece: movingPiece,
-      isPromotion: true,
-    );
-
-    // 创建新的双步兵记录
-    final newLastPawnDoubleMoved = Map<PieceColor, Position?>.from(state.lastPawnDoubleMoved);
-    final newLastPawnDoubleMovedNumber = Map<PieceColor, int>.from(state.lastPawnDoubleMovedNumber);
-
-    // 保存当前状态到撤销列表
-    final newUndoStates = List<GameState>.from(state.undoStates)..add(state);
-
-    emit(state.copyWith(
-      board: newBoard,
-      selectedPosition: null,
-      validMoves: [],
-      lastPawnDoubleMoved: newLastPawnDoubleMoved,
-      lastPawnDoubleMovedNumber: newLastPawnDoubleMovedNumber,
-      currentMoveNumber: state.currentMoveNumber + 1,
-      moveHistory: [...state.moveHistory, move],
-      lastMove: move,
-      undoStates: newUndoStates,
-      redoStates: [], // 清空重做列表
-    ));
-  }
-
-  void _handleRegularMove(MovePiece event, ChessPiece movingPiece, ChessPiece? capturedPiece, List<List<ChessPiece?>> newBoard, Position? newLastPawnDoubleMoved, Emitter<GameState> emit) {
-    newBoard[event.to.row][event.to.col] = movingPiece;
-    newBoard[event.from.row][event.from.col] = null;
-
-    Map<PieceColor, Map<String, bool>>? newHasRookMoved;
-    if (movingPiece.type == PieceType.rook) {
-      newHasRookMoved = Map<PieceColor, Map<String, bool>>.from(
-        state.hasRookMoved.map(
-          (color, value) => MapEntry(
-            color,
-            Map<String, bool>.from(value),
-          ),
-        ),
-      );
-      if (event.from.col == 0) {
-        newHasRookMoved[movingPiece.color]!['queenside'] = true;
-      } else if (event.from.col == 7) {
-        newHasRookMoved[movingPiece.color]!['kingside'] = true;
-      }
-    }
-
-    Map<PieceColor, bool> newHasKingMoved = Map<PieceColor, bool>.from(state.hasKingMoved);
-    if (movingPiece.type == PieceType.king) {
-      newHasKingMoved[movingPiece.color] = true;
-    }
-
-    // 更新双步兵记录
-    final newLastPawnDoubleMoved = Map<PieceColor, Position?>.from(state.lastPawnDoubleMoved);
-    final newLastPawnDoubleMovedNumber = Map<PieceColor, int>.from(state.lastPawnDoubleMovedNumber);
-
-    if (movingPiece.type == PieceType.pawn && (event.from.row - event.to.row).abs() == 2) {
-      newLastPawnDoubleMoved[movingPiece.color] = event.to;
-      newLastPawnDoubleMovedNumber[movingPiece.color] = state.currentMoveNumber;
-    } else {
-      // 如果不是双步移动，清除当前玩家的双步兵记录
-      newLastPawnDoubleMoved[movingPiece.color] = null;
-      newLastPawnDoubleMovedNumber[movingPiece.color] = -1;
-    }
-
-    final move = ChessMove(
-      from: event.from,
-      to: event.to,
-      piece: movingPiece,
-      capturedPiece: capturedPiece,
-      isEnPassant: false,
-    );
-
-    // 生成移动提示信息
-    String message;
-    if (capturedPiece != null) {
-      message = '${movingPiece.color == PieceColor.white ? "白方" : "黑方"}${_getPieceTypeName(movingPiece.type)}(${_getPositionName(event.from)})吃掉${capturedPiece.color == PieceColor.white ? "白方" : "黑方"}${_getPieceTypeName(capturedPiece.type)}(${_getPositionName(event.to)})';
-    } else {
-      message = '${movingPiece.color == PieceColor.white ? "白方" : "黑方"}${_getPieceTypeName(movingPiece.type)}从${_getPositionName(event.from)}移动到${_getPositionName(event.to)}';
-    }
-
-    // 检查对手是否被将军或将死
-    final nextPlayer = state.currentPlayer == PieceColor.white ? PieceColor.black : PieceColor.white;
-    final isCheck = ChessRules.isInCheck(newBoard, nextPlayer);
-    final isCheckmate = isCheck && ChessRules.isCheckmate(
-      newBoard,
-      nextPlayer,
-      newHasKingMoved,
-      newHasRookMoved ?? state.hasRookMoved,
-      newLastPawnDoubleMoved,
-      newLastPawnDoubleMovedNumber,
-      state.currentMoveNumber + 1,
-    );
-    final isStalemate = !isCheck && ChessRules.isStalemate(
-      newBoard,
-      nextPlayer,
-      newHasKingMoved,
-      newHasRookMoved ?? state.hasRookMoved,
-      newLastPawnDoubleMoved,
-      newLastPawnDoubleMovedNumber,
-      state.currentMoveNumber + 1,
-    );
-
-    // 添加将军或将死的提示
-    if (isCheckmate) {
-      message += ' 将死！${state.currentPlayer == PieceColor.white ? "白方" : "黑方"}获胜！';
-    } else if (isCheck) {
-      message += ' 将军！';
-    } else if (isStalemate) {
-      message += ' 和棋！';
-    }
-
-    // 保存当前状态到撤销列表
-    final newUndoStates = List<GameState>.from(state.undoStates)..add(state);
-
-    emit(state.copyWith(
-      board: newBoard,
-      currentPlayer: nextPlayer,
-      selectedPosition: null,
-      validMoves: [],
-      hasKingMoved: newHasKingMoved,
-      hasRookMoved: newHasRookMoved,
-      lastPawnDoubleMoved: newLastPawnDoubleMoved,
-      lastPawnDoubleMovedNumber: newLastPawnDoubleMovedNumber,
-      currentMoveNumber: state.currentMoveNumber + 1,
-      moveHistory: [...state.moveHistory, move],
-      specialMoveMessage: message,
-      lastMove: move,
-      isCheck: isCheck,
-      isCheckmate: isCheckmate,
-      isStalemate: isStalemate,
-      undoStates: newUndoStates,
-      redoStates: [], // 清空重做列表
-    ));
-  }
-
-  String _getPositionName(Position position) {
-    final col = String.fromCharCode('A'.codeUnitAt(0) + position.col);
-    final row = 8 - position.row;
-    return '$col$row';
-  }
-
-  String _getPieceTypeName(PieceType type) {
-    switch (type) {
-      case PieceType.king:
-        return "王";
-      case PieceType.queen:
-        return "后";
-      case PieceType.bishop:
-        return "象";
-      case PieceType.knight:
-        return "马";
-      case PieceType.rook:
-        return "车";
-      case PieceType.pawn:
-        return "兵";
-    }
+    
+    final newState = _gameLogicService.handleMove(state, event.from, event.to);
+    emit(newState);
   }
 
   void _onPromotePawn(PromotePawn event, Emitter<GameState> emit) {
-    final newBoard = List<List<ChessPiece?>>.from(
-      state.board.map((row) => List<ChessPiece?>.from(row))
-    );
-    final pawn = newBoard[event.position.row][event.position.col]!;
-    final promotedPiece = ChessPiece(
-      type: event.promotionType,
-      color: pawn.color,
-    );
-
-    newBoard[event.position.row][event.position.col] = promotedPiece;
-
-    // 获取最后一步移动
-    final lastMove = state.moveHistory.last.copyWith(
-      isPromotion: true,
-      promotionType: event.promotionType,
-    );
-
-    // 检查对手是否被将军或将死
-    final nextPlayer = state.currentPlayer == PieceColor.white ? PieceColor.black : PieceColor.white;
-    final isCheck = ChessRules.isInCheck(newBoard, nextPlayer);
-    final isCheckmate = isCheck && ChessRules.isCheckmate(
-      newBoard,
-      nextPlayer,
-      state.hasKingMoved,
-      state.hasRookMoved,
-      state.lastPawnDoubleMoved,
-      state.lastPawnDoubleMovedNumber,
-      state.currentMoveNumber + 1,
-    );
-    final isStalemate = !isCheck && ChessRules.isStalemate(
-      newBoard,
-      nextPlayer,
-      state.hasKingMoved,
-      state.hasRookMoved,
-      state.lastPawnDoubleMoved,
-      state.lastPawnDoubleMovedNumber,
-      state.currentMoveNumber + 1,
-    );
-
-    String message = '${pawn.color == PieceColor.white ? "白方" : "黑方"}兵从${_getPositionName(lastMove.from)}升变为${_getPieceTypeName(event.promotionType)}到${_getPositionName(lastMove.to)}';
-
-    // 添加将军或将死的提示
-    if (isCheckmate) {
-      message += ' 将死！${state.currentPlayer == PieceColor.white ? "白方" : "黑方"}获胜！';
-    } else if (isCheck) {
-      message += ' 将军！';
-    } else if (isStalemate) {
-      message += ' 和棋！';
+    // Ensure that a promotion is actually pending and the position matches.
+    if (!state.isPendingPromotion || state.promotionPosition != event.position) {
+      // This event should only occur when state.isPendingPromotion is true
+      // and event.position matches state.promotionPosition.
+      // If not, it's an unexpected event, so we might ignore it or log an error.
+      return;
     }
-
-    // 保存当前状态到撤销列表
-    final newUndoStates = List<GameState>.from(state.undoStates)..add(state);
-
-    emit(state.copyWith(
-      board: newBoard,
-      currentPlayer: nextPlayer,
-      moveHistory: [
-        ...state.moveHistory.sublist(0, state.moveHistory.length - 1),
-        lastMove,
-      ],
-      specialMoveMessage: message,
-      lastMove: lastMove,
-      isCheck: isCheck,
-      isCheckmate: isCheckmate,
-      isStalemate: isStalemate,
-      undoStates: newUndoStates,
-      redoStates: [], // 清空重做列表
-    ));
+    final newState = _gameLogicService.completePawnPromotion(state, event.promotionType);
+    emit(newState);
   }
 
   void _onUndoMove(UndoMove event, Emitter<GameState> emit) {
     if (state.undoStates.isEmpty) return;
 
-    // 获取前一步的状态
     final previousState = state.undoStates.last;
     final newUndoStates = List<GameState>.from(state.undoStates)..removeLast();
 
-    // 将当前状态添加到重做列表的开头
     final newRedoStates = List<GameState>.from(state.redoStates)
-      ..insert(0, state.copyWith(
-        undoStates: newUndoStates,
-        redoStates: [],
+      ..insert(0, state.copyWith( // current state before undoing
+        undoStates: newUndoStates, // this will be the undoStates of the *next* state if we redo
+        redoStates: [], // redoStates are cleared when a new move is made or state changes not via redo
+        // Ensure other relevant fields are part of this copy if they could change
+        // but for undo/redo, we are primarily restoring a past state.
       ));
 
+    // When emitting the previousState, we also need to provide it with the updated redoStates list.
     emit(previousState.copyWith(
-      moveHistory: state.moveHistory,
+      // moveHistory is part of the state snapshot, so it's restored.
       undoStates: newUndoStates,
-      redoStates: newRedoStates,
-      selectedPosition: null,
-      validMoves: [],
+      redoStates: newRedoStates, // crucial for enabling redo
+      selectedPosition: null, // Clear selection when undoing
+      validMoves: [], // Clear valid moves
     ));
   }
 
   void _onRedoMove(RedoMove event, Emitter<GameState> emit) {
     if (state.redoStates.isEmpty) return;
 
-    // 获取下一步的状态
-    final nextState = state.redoStates[0];
+    final nextState = state.redoStates.first; // Get the state to redo
     final newRedoStates = List<GameState>.from(state.redoStates)..removeAt(0);
 
-    // 将当前状态添加到撤销列表
-    final newUndoStates = List<GameState>.from(state.undoStates)..add(state);
+    // Current state before redoing is added to undoStates
+    final newUndoStates = List<GameState>.from(state.undoStates)..add(state.copyWith(
+      // Ensure this copy is what we want on the undo stack.
+      // Typically, it's the state just before this redo operation.
+      undoStates: state.undoStates, // This will be the undo stack of the current state
+      redoStates: newRedoStates, // This will be the redo stack of the current state
+    ));
 
+    // Emit the nextState (the one we are redoing to)
+    // It should already have its own correct undo/redo stacks from when it was previously current.
+    // However, the standard practice is to manage undo/redo stacks centrally.
+    // So, we update the emitted state's undo/redo lists.
     emit(nextState.copyWith(
-      moveHistory: state.moveHistory,
       undoStates: newUndoStates,
       redoStates: newRedoStates,
-      selectedPosition: null,
-      validMoves: [],
+      selectedPosition: null, // Clear selection when redoing
+      validMoves: [], // Clear valid moves
     ));
   }
 
   void _onSaveGame(SaveGame event, Emitter<GameState> emit) {
-    // TODO: 实现保存游戏功能
+    // TODO: Implement save game functionality
   }
 
   void _onLoadGame(LoadGame event, Emitter<GameState> emit) {
-    // TODO: 实现加载游戏功能
+    // TODO: Implement load game functionality
   }
 
   void _onToggleHintMode(ToggleHintMode event, Emitter<GameState> emit) {
     emit(state.copyWith(
       hintMode: !state.hintMode,
-      selectedPosition: state.selectedPosition,
+      // selectedPosition and validMoves should persist through hint mode toggle
+      // If a piece is selected, its valid moves should still be shown or hidden based on new hintMode.
+      selectedPosition: state.selectedPosition, 
       validMoves: state.validMoves,
     ));
   }
@@ -727,11 +252,11 @@ class ChessBloc extends Bloc<ChessEvent, GameState> {
     StartNewGameFromCurrentPosition event,
     Emitter<GameState> emit,
   ) {
-    // 从当前棋局创建新的游戏状态
+    // Create new game state from current board
     final newState = state.copyWith(
-      // 保持当前棋盘状态
-      currentPlayer: state.currentPlayer,
-      // 清除历史记录和状态
+      // Keep current board state
+      currentPlayer: state.currentPlayer, // Or allow specifying starting player
+      // Clear history and status
       moveHistory: [],
       undoStates: [],
       redoStates: [],
@@ -739,16 +264,18 @@ class ChessBloc extends Bloc<ChessEvent, GameState> {
       validMoves: [],
       specialMoveMessage: null,
       lastMove: null,
-      // 设置新的游戏模式和交互状态
+      // Set new game mode and interactivity
       gameMode: event.gameMode,
       isInteractive: event.isInteractive,
       allowedPlayer: event.allowedPlayer,
-      // 重置检查状态
+      // Reset check/game over states
       isCheck: false,
       isCheckmate: false,
       isStalemate: false,
-      // 重置移动计数
-      currentMoveNumber: 0,
+      isPendingPromotion: false,
+      promotionPosition: null,
+      // Reset move count
+      currentMoveNumber: 0, // A new game starts from move 0
     );
 
     emit(newState);
@@ -761,6 +288,9 @@ class ChessBloc extends Bloc<ChessEvent, GameState> {
     emit(state.copyWith(
       isInteractive: event.isInteractive,
       allowedPlayer: event.allowedPlayer,
+      // If board becomes non-interactive, clear selection and valid moves
+      selectedPosition: event.isInteractive ? state.selectedPosition : null,
+      validMoves: event.isInteractive ? state.validMoves : [],
     ));
   }
 

--- a/lib/services/game_logic_service.dart
+++ b/lib/services/game_logic_service.dart
@@ -1,0 +1,640 @@
+import '../models/chess_models.dart';
+import '../utils/chess_rules.dart';
+
+class GameLogicService {
+  // Method to apply a move to the board
+  GameState applyMove(GameState state, ChessMove move) {
+    // Create a new board state
+    final newBoard = List<List<ChessPiece?>>.from(
+      state.board.map((row) => List<ChessPiece?>.from(row)),
+    );
+
+    // Move the piece
+    newBoard[move.to.row][move.to.col] = move.piece;
+    newBoard[move.from.row][move.from.col] = null;
+
+    // Handle en passant capture
+    if (move.isEnPassant) {
+      // The pawn captured via en passant is at the 'to' square's row and the 'from' square's column.
+      // This logic seems to be handled in _handleEnPassant in ChessBloc by removing the captured pawn directly.
+      // For applyMove, we'd expect the captured pawn's original square to be cleared.
+      // In an en passant move, the 'to' square is empty before the move, and the captured pawn is adjacent.
+      // The move object itself should ideally carry enough info.
+      // If 'move.capturedPiece' is the en passant captured pawn, its original position is what needs to be cleared.
+      // Assuming the en passant capture implies the captured pawn is at move.from.row, move.to.col
+      newBoard[move.from.row][move.to.col] = null;
+    }
+
+    // Handle castling
+    if (move.isCastling) {
+      final rookFromCol = move.to.col > move.from.col ? 7 : 0; // King moves two squares, rook is on that side
+      final rookToCol = move.to.col > move.from.col ? move.to.col - 1 : move.to.col + 1; // Rook moves next to king
+      
+      // Move the rook
+      final rook = newBoard[move.from.row][rookFromCol];
+      newBoard[move.from.row][rookToCol] = rook;
+      newBoard[move.from.row][rookFromCol] = null;
+    }
+
+    // Handle pawn promotion
+    if (move.isPromotion && move.promotionType != null) {
+      newBoard[move.to.row][move.to.col] = ChessPiece(
+        type: move.promotionType!,
+        color: move.piece.color,
+      );
+    }
+
+    // Update and return the new game state
+    // Note: Switching currentPlayer, updating move history, etc., are typically handled
+    // by the calling Bloc/service after this pure board manipulation.
+    // For now, this method focuses on applying the move to the board.
+    // The original _applyMove in ChessBloc also updated currentPlayer and moveHistory.
+    // We will replicate that behavior here for consistency during refactoring.
+    return state.copyWith(
+      board: newBoard,
+      currentPlayer: state.currentPlayer == PieceColor.white ? PieceColor.black : PieceColor.white,
+      selectedPosition: null, // Clear selection after move
+      validMoves: const [], // Clear valid moves
+      moveHistory: List.from(state.moveHistory)..add(move),
+      lastMove: move,
+      // Other state updates like hasKingMoved, hasRookMoved, lastPawnDoubleMoved
+      // will be handled by more specific methods that call applyMove or by the Bloc.
+      // For now, this is a direct translation of the board manipulation part.
+    );
+  }
+
+  // Method to select a piece and determine valid moves
+  // This was the original stub_out, we are replacing it with getValidMovesForPiece
+  // List<Move> selectPiece(GameState gameState, Piece piece) { 
+  //   // Implementation will be added later
+  //   return [];
+  // }
+
+  List<Position> getValidMovesForPiece(GameState gameState, Position selectedPosition) {
+    // If the board is not interactive or the game is over, no moves are valid.
+    if (!gameState.isInteractive || gameState.isCheckmate || gameState.isStalemate) {
+      return [];
+    }
+
+    // If a specific player's turn is enforced and it's not the current player, no moves.
+    if (gameState.allowedPlayer != null && gameState.currentPlayer != gameState.allowedPlayer) {
+      return [];
+    }
+
+    final piece = gameState.board[selectedPosition.row][selectedPosition.col];
+
+    // If there's no piece at the selected position or it's not the current player's piece.
+    if (piece == null || piece.color != gameState.currentPlayer) {
+      return [];
+    }
+
+    // Determine the opponent's color for en passant check.
+    final opponentColor = piece.color == PieceColor.white ? PieceColor.black : PieceColor.white;
+
+    // Get valid moves from ChessRules.
+    final validMoves = ChessRules.getValidMoves(
+      gameState.board,
+      selectedPosition,
+      hasKingMoved: gameState.hasKingMoved,
+      hasRookMoved: gameState.hasRookMoved,
+      lastPawnDoubleMoved: gameState.lastPawnDoubleMoved[opponentColor],
+      lastPawnDoubleMovedNumber: gameState.lastPawnDoubleMovedNumber[opponentColor],
+      currentMoveNumber: gameState.currentMoveNumber,
+    );
+
+    return validMoves;
+  }
+
+  // Method to handle pawn promotion
+  GameState handlePawnPromotion(GameState gameState, Piece promotedPiece) {
+    // Implementation will be added later
+    return gameState;
+  }
+
+  // Method to handle castling
+  GameState handleCastling(GameState gameState, Move move) {
+    // Implementation will be added later
+    return gameState;
+  }
+
+  // Method to handle en passant
+  GameState handleEnPassant(GameState gameState, ChessMove move) {
+    // Implementation will be added later
+    return gameState;
+  }
+
+  // Helper methods moved from ChessBloc
+  static String _getPositionName(Position position) {
+    final col = String.fromCharCode('A'.codeUnitAt(0) + position.col);
+    final row = 8 - position.row;
+    return '$col$row';
+  }
+
+  static String _getPieceTypeName(PieceType type) {
+    switch (type) {
+      case PieceType.king:
+        return "王";
+      case PieceType.queen:
+        return "后";
+      case PieceType.bishop:
+        return "象";
+      case PieceType.knight:
+        return "马";
+      case PieceType.rook:
+        return "车";
+      case PieceType.pawn:
+        return "兵";
+    }
+  }
+
+  bool _isCastlingMove(ChessPiece movingPiece, Position from, Position to) {
+    return movingPiece.type == PieceType.king &&
+           (from.col - to.col).abs() == 2;
+  }
+
+  bool _isPawnDoubleMove(ChessPiece movingPiece, Position from, Position to) {
+    return movingPiece.type == PieceType.pawn &&
+           (from.row - to.row).abs() == 2;
+  }
+
+  bool _isEnPassantMove(GameState state, ChessPiece movingPiece, Position from, Position to, ChessPiece? capturedPiece) {
+    final opponentColor = movingPiece.color == PieceColor.white ? PieceColor.black : PieceColor.white;
+    final opponentLastPawnDoubleMoved = state.lastPawnDoubleMoved[opponentColor];
+    final opponentLastMoveNumber = state.lastPawnDoubleMovedNumber[opponentColor];
+
+    if (movingPiece.type != PieceType.pawn ||
+        opponentLastPawnDoubleMoved == null ||
+        from.col == to.col || // Must be a diagonal move for pawn capture
+        opponentLastMoveNumber != state.currentMoveNumber -1) { // En passant only on the very next turn
+      return false;
+    }
+    
+    // Check if the 'to' position is the correct en passant square
+    if (movingPiece.color == PieceColor.white) {
+      return from.row == 3 && // White pawn on 5th rank (row 3)
+             to.row == 2 && // Moves to 6th rank (row 2)
+             opponentLastPawnDoubleMoved.row == 3 && // Opponent pawn was on 5th rank
+             opponentLastPawnDoubleMoved.col == to.col; // Opponent pawn is in the same column as 'to'
+    } else { // Black pawn
+      return from.row == 4 && // Black pawn on 4th rank (row 4)
+             to.row == 5 && // Moves to 3rd rank (row 5)
+             opponentLastPawnDoubleMoved.row == 4 && // Opponent pawn was on 4th rank
+             opponentLastPawnDoubleMoved.col == to.col; // Opponent pawn is in the same column as 'to'
+    }
+  }
+
+  bool _isPawnPromotion(ChessPiece movingPiece, Position to) {
+    return movingPiece.type == PieceType.pawn &&
+           (to.row == 0 || to.row == 7);
+  }
+
+  GameState _handleRegularMoveLogic(
+    GameState state,
+    ChessPiece movingPiece,
+    ChessPiece? capturedPiece,
+    Position from,
+    Position to,
+    List<List<ChessPiece?>> newBoard,
+  ) {
+    newBoard[to.row][to.col] = movingPiece;
+    newBoard[from.row][from.col] = null;
+
+    Map<PieceColor, Map<String, bool>> newHasRookMoved = Map.from(state.hasRookMoved.map(
+      (key, value) => MapEntry(key, Map.from(value)),
+    ));
+    if (movingPiece.type == PieceType.rook) {
+      if (from.col == 0 && from.row == (movingPiece.color == PieceColor.white ? 7 : 0)) {
+        newHasRookMoved[movingPiece.color]!['queenside'] = true;
+      } else if (from.col == 7 && from.row == (movingPiece.color == PieceColor.white ? 7 : 0)) {
+        newHasRookMoved[movingPiece.color]!['kingside'] = true;
+      }
+    }
+
+    Map<PieceColor, bool> newHasKingMoved = Map.from(state.hasKingMoved);
+    if (movingPiece.type == PieceType.king) {
+      newHasKingMoved[movingPiece.color] = true;
+    }
+
+    final newLastPawnDoubleMoved = Map<PieceColor, Position?>.from(state.lastPawnDoubleMoved);
+    final newLastPawnDoubleMovedNumber = Map<PieceColor, int>.from(state.lastPawnDoubleMovedNumber);
+
+    if (movingPiece.type == PieceType.pawn && (from.row - to.row).abs() == 2) {
+      newLastPawnDoubleMoved[movingPiece.color] = to;
+      newLastPawnDoubleMovedNumber[movingPiece.color] = state.currentMoveNumber;
+    } else {
+      // Clear previous double move for the current player if this wasn't a double move
+       if (newLastPawnDoubleMoved[movingPiece.color] != null) {
+          newLastPawnDoubleMoved[movingPiece.color] = null;
+          newLastPawnDoubleMovedNumber[movingPiece.color] = -1;
+       }
+    }
+    // Clear opponent's en passant if it wasn't taken this turn
+    final opponentColor = movingPiece.color == PieceColor.white ? PieceColor.black : PieceColor.white;
+    if (newLastPawnDoubleMoved[opponentColor] != null && newLastPawnDoubleMovedNumber[opponentColor] != state.currentMoveNumber -1 ) {
+        newLastPawnDoubleMoved[opponentColor] = null;
+        newLastPawnDoubleMovedNumber[opponentColor] = -1;
+    }
+
+
+    final move = ChessMove(
+      from: from,
+      to: to,
+      piece: movingPiece,
+      capturedPiece: capturedPiece,
+    );
+
+    String message;
+    if (capturedPiece != null) {
+      message = '${movingPiece.color == PieceColor.white ? "White" : "Black"} ${_getPieceTypeName(movingPiece.type)} from ${_getPositionName(from)} captures ${capturedPiece.color == PieceColor.white ? "White" : "Black"} ${_getPieceTypeName(capturedPiece.type)} at ${_getPositionName(to)}';
+    } else {
+      message = '${movingPiece.color == PieceColor.white ? "White" : "Black"} ${_getPieceTypeName(movingPiece.type)} moves from ${_getPositionName(from)} to ${_getPositionName(to)}';
+    }
+
+    final nextPlayer = state.currentPlayer == PieceColor.white ? PieceColor.black : PieceColor.white;
+    final isCheck = ChessRules.isInCheck(newBoard, nextPlayer);
+    final isCheckmate = isCheck && ChessRules.isCheckmate(
+      newBoard,
+      nextPlayer,
+      newHasKingMoved,
+      newHasRookMoved,
+      newLastPawnDoubleMoved,
+      newLastPawnDoubleMovedNumber,
+      state.currentMoveNumber + 1,
+    );
+    final isStalemate = !isCheck && ChessRules.isStalemate(
+      newBoard,
+      nextPlayer,
+      newHasKingMoved,
+      newHasRookMoved,
+      newLastPawnDoubleMoved,
+      newLastPawnDoubleMovedNumber,
+      state.currentMoveNumber + 1,
+    );
+
+    if (isCheckmate) {
+      message += '. Checkmate! ${state.currentPlayer == PieceColor.white ? "White" : "Black"} wins!';
+    } else if (isStalemate) {
+      message += '. Stalemate! The game is a draw.';
+    } else if (isCheck) {
+      message += '. Check!';
+    }
+    
+    final newUndoStates = List<GameState>.from(state.undoStates)..add(state.copyWith(selectedPosition: null, validMoves: []));
+
+
+    return state.copyWith(
+      board: newBoard,
+      currentPlayer: nextPlayer,
+      selectedPosition: null,
+      validMoves: [],
+      hasKingMoved: newHasKingMoved,
+      hasRookMoved: newHasRookMoved,
+      lastPawnDoubleMoved: newLastPawnDoubleMoved,
+      lastPawnDoubleMovedNumber: newLastPawnDoubleMovedNumber,
+      currentMoveNumber: state.currentMoveNumber + 1,
+      moveHistory: List.from(state.moveHistory)..add(move),
+      specialMoveMessage: message,
+      lastMove: move,
+      isCheck: isCheck,
+      isCheckmate: isCheckmate,
+      isStalemate: isStalemate,
+      undoStates: newUndoStates,
+      redoStates: [],
+    );
+  }
+
+  GameState _handleCastlingLogic(
+    GameState state,
+    ChessPiece movingPiece,
+    Position from,
+    Position to,
+    List<List<ChessPiece?>> newBoard,
+  ) {
+    final isKingside = to.col > from.col;
+    final rookFromCol = isKingside ? 7 : 0;
+    final rookToCol = isKingside ? 5 : 3;
+
+    newBoard[to.row][to.col] = movingPiece;
+    newBoard[from.row][from.col] = null;
+    newBoard[from.row][rookToCol] = state.board[from.row][rookFromCol];
+    newBoard[from.row][rookFromCol] = null;
+
+    final newHasKingMoved = Map<PieceColor, bool>.from(state.hasKingMoved);
+    newHasKingMoved[movingPiece.color] = true;
+
+    // Mark rooks as moved too for the castled side
+    final newHasRookMoved = Map<PieceColor, Map<String, bool>>.from(state.hasRookMoved.map(
+      (key, value) => MapEntry(key, Map.from(value)),
+    ));
+    newHasRookMoved[movingPiece.color]![isKingside ? 'kingside' : 'queenside'] = true;
+
+
+    final move = ChessMove(
+      from: from,
+      to: to,
+      piece: movingPiece,
+      isCastling: true,
+    );
+
+    String message = '${movingPiece.color == PieceColor.white ? "White" : "Black"} castles ${isKingside ? "kingside" : "queenside"} from ${_getPositionName(from)} to ${_getPositionName(to)}';
+
+    final nextPlayer = state.currentPlayer == PieceColor.white ? PieceColor.black : PieceColor.white;
+    final isCheck = ChessRules.isInCheck(newBoard, nextPlayer);
+    final isCheckmate = isCheck && ChessRules.isCheckmate(
+      newBoard,
+      nextPlayer,
+      newHasKingMoved,
+      newHasRookMoved,
+      state.lastPawnDoubleMoved,
+      state.lastPawnDoubleMovedNumber,
+      state.currentMoveNumber + 1,
+    );
+    final isStalemate = !isCheck && ChessRules.isStalemate(
+      newBoard,
+      nextPlayer,
+      newHasKingMoved,
+      newHasRookMoved,
+      state.lastPawnDoubleMoved,
+      state.lastPawnDoubleMovedNumber,
+      state.currentMoveNumber + 1,
+    );
+
+    if (isCheckmate) {
+      message += '. Checkmate! ${state.currentPlayer == PieceColor.white ? "White" : "Black"} wins!';
+    } else if (isStalemate) {
+      message += '. Stalemate! The game is a draw.';
+    } else if (isCheck) {
+      message += '. Check!';
+    }
+    
+    final newUndoStates = List<GameState>.from(state.undoStates)..add(state.copyWith(selectedPosition: null, validMoves: []));
+
+    return state.copyWith(
+      board: newBoard,
+      currentPlayer: nextPlayer,
+      selectedPosition: null,
+      validMoves: [],
+      hasKingMoved: newHasKingMoved,
+      hasRookMoved: newHasRookMoved,
+      currentMoveNumber: state.currentMoveNumber + 1,
+      moveHistory: List.from(state.moveHistory)..add(move),
+      specialMoveMessage: message,
+      lastMove: move,
+      isCheck: isCheck,
+      isCheckmate: isCheckmate,
+      isStalemate: isStalemate,
+      undoStates: newUndoStates,
+      redoStates: [],
+    );
+  }
+
+  GameState _handleEnPassantLogic(
+    GameState state,
+    ChessPiece movingPiece,
+    Position from,
+    Position to,
+    List<List<ChessPiece?>> newBoard,
+  ) {
+    final opponentColor = movingPiece.color == PieceColor.white ? PieceColor.black : PieceColor.white;
+    final capturedPawnPosition = Position(from.row, to.col); // Captured pawn is on the same rank as 'from', and same col as 'to'
+    final capturedPawn = state.board[capturedPawnPosition.row][capturedPawnPosition.col]!;
+
+    newBoard[to.row][to.col] = movingPiece;
+    newBoard[from.row][from.col] = null;
+    newBoard[capturedPawnPosition.row][capturedPawnPosition.col] = null; // Remove captured pawn
+
+    final move = ChessMove(
+      from: from,
+      to: to,
+      piece: movingPiece,
+      capturedPiece: capturedPawn,
+      isEnPassant: true,
+    );
+
+    final newLastPawnDoubleMoved = Map<PieceColor, Position?>.from(state.lastPawnDoubleMoved);
+    final newLastPawnDoubleMovedNumber = Map<PieceColor, int>.from(state.lastPawnDoubleMovedNumber);
+    newLastPawnDoubleMoved[opponentColor] = null; // Clear the en passant flag for the captured pawn
+    newLastPawnDoubleMovedNumber[opponentColor] = -1;
+
+    String message = '${movingPiece.color == PieceColor.white ? "White" : "Black"} pawn from ${_getPositionName(from)} captures en passant at ${_getPositionName(to)}';
+
+    final nextPlayer = state.currentPlayer == PieceColor.white ? PieceColor.black : PieceColor.white;
+    final isCheck = ChessRules.isInCheck(newBoard, nextPlayer);
+    final isCheckmate = isCheck && ChessRules.isCheckmate(
+      newBoard,
+      nextPlayer,
+      state.hasKingMoved,
+      state.hasRookMoved,
+      newLastPawnDoubleMoved,
+      newLastPawnDoubleMovedNumber,
+      state.currentMoveNumber + 1,
+    );
+    final isStalemate = !isCheck && ChessRules.isStalemate(
+      newBoard,
+      nextPlayer,
+      state.hasKingMoved,
+      state.hasRookMoved,
+      newLastPawnDoubleMoved,
+      newLastPawnDoubleMovedNumber,
+      state.currentMoveNumber + 1,
+    );
+
+    if (isCheckmate) {
+      message += '. Checkmate! ${state.currentPlayer == PieceColor.white ? "White" : "Black"} wins!';
+    } else if (isStalemate) {
+      message += '. Stalemate! The game is a draw.';
+    } else if (isCheck) {
+      message += '. Check!';
+    }
+
+    final newUndoStates = List<GameState>.from(state.undoStates)..add(state.copyWith(selectedPosition: null, validMoves: []));
+
+    return state.copyWith(
+      board: newBoard,
+      currentPlayer: nextPlayer,
+      selectedPosition: null,
+      validMoves: [],
+      lastPawnDoubleMoved: newLastPawnDoubleMoved,
+      lastPawnDoubleMovedNumber: newLastPawnDoubleMovedNumber,
+      currentMoveNumber: state.currentMoveNumber + 1,
+      moveHistory: List.from(state.moveHistory)..add(move),
+      specialMoveMessage: message,
+      lastMove: move,
+      isCheck: isCheck,
+      isCheckmate: isCheckmate,
+      isStalemate: isStalemate,
+      undoStates: newUndoStates,
+      redoStates: [],
+    );
+  }
+
+  GameState _handlePawnPromotionLogic(
+    GameState state,
+    ChessPiece movingPiece,
+    Position from,
+    Position to,
+    List<List<ChessPiece?>> newBoard,
+  ) {
+    newBoard[to.row][to.col] = movingPiece; // Temporarily place the pawn
+    newBoard[from.row][from.col] = null;
+
+    final move = ChessMove(
+      from: from,
+      to: to,
+      piece: movingPiece,
+      isPromotion: true, // Mark as promotion
+      // promotionType will be set by completePawnPromotion
+    );
+    
+    // Clear opponent's en passant if it wasn't taken this turn
+    final opponentColor = movingPiece.color == PieceColor.white ? PieceColor.black : PieceColor.white;
+    final newLastPawnDoubleMoved = Map<PieceColor, Position?>.from(state.lastPawnDoubleMoved);
+    final newLastPawnDoubleMovedNumber = Map<PieceColor, int>.from(state.lastPawnDoubleMovedNumber);
+    if (newLastPawnDoubleMoved[opponentColor] != null && newLastPawnDoubleMovedNumber[opponentColor] != state.currentMoveNumber -1 ) {
+        newLastPawnDoubleMoved[opponentColor] = null;
+        newLastPawnDoubleMovedNumber[opponentColor] = -1;
+    }
+
+
+    // The game state is now pending promotion. Current player does not change yet.
+    // Undo states should store the state *before* this pending promotion.
+    final newUndoStates = List<GameState>.from(state.undoStates)..add(state.copyWith(selectedPosition: null, validMoves: []));
+
+
+    return state.copyWith(
+      board: newBoard, // Board shows pawn at the promotion square
+      selectedPosition: null,
+      validMoves: [],
+      lastPawnDoubleMoved: newLastPawnDoubleMoved, // En passant state might have changed
+      lastPawnDoubleMovedNumber: newLastPawnDoubleMovedNumber,
+      // currentMoveNumber and currentPlayer do not change yet
+      // moveHistory will be updated by completePawnPromotion
+      // specialMoveMessage will be set by completePawnPromotion
+      lastMove: move, // Store the pending promotion move
+      isPendingPromotion: true, // Signal UI to ask for promotion choice
+      promotionPosition: to, // Store where promotion is happening
+      undoStates: newUndoStates,
+      redoStates: [],
+    );
+  }
+
+  GameState completePawnPromotion(
+    GameState state,
+    PieceType promotionType,
+  ) {
+    if (!state.isPendingPromotion || state.promotionPosition == null || state.lastMove == null) {
+      // Should not happen if called correctly
+      return state;
+    }
+
+    final newBoard = List<List<ChessPiece?>>.from(
+      state.board.map((row) => List<ChessPiece?>.from(row)),
+    );
+    final pawn = newBoard[state.promotionPosition!.row][state.promotionPosition!.col]!;
+    final promotedPiece = ChessPiece(
+      type: promotionType,
+      color: pawn.color,
+    );
+
+    newBoard[state.promotionPosition!.row][state.promotionPosition!.col] = promotedPiece;
+
+    final lastMove = state.lastMove!.copyWith(
+      promotionType: promotionType, // Now set the actual promotion type
+      piece: promotedPiece, // The move is now considered to be by the promoted piece
+    );
+
+    String message = '${pawn.color == PieceColor.white ? "White" : "Black"} pawn promotes to ${_getPieceTypeName(promotionType)} at ${_getPositionName(state.promotionPosition!)}';
+
+    final nextPlayer = state.currentPlayer == PieceColor.white ? PieceColor.black : PieceColor.white;
+    final isCheck = ChessRules.isInCheck(newBoard, nextPlayer);
+    final isCheckmate = isCheck && ChessRules.isCheckmate(
+      newBoard,
+      nextPlayer,
+      state.hasKingMoved,
+      state.hasRookMoved,
+      state.lastPawnDoubleMoved,
+      state.lastPawnDoubleMovedNumber,
+      state.currentMoveNumber + 1, // Promotion completes the move
+    );
+    final isStalemate = !isCheck && ChessRules.isStalemate(
+      newBoard,
+      nextPlayer,
+      state.hasKingMoved,
+      state.hasRookMoved,
+      state.lastPawnDoubleMoved,
+      state.lastPawnDoubleMovedNumber,
+      state.currentMoveNumber + 1,
+    );
+
+    if (isCheckmate) {
+      message += '. Checkmate! ${state.currentPlayer == PieceColor.white ? "White" : "Black"} wins!';
+    } else if (isStalemate) {
+      message += '. Stalemate! The game is a draw.';
+    } else if (isCheck) {
+      message += '. Check!';
+    }
+    
+    // The undo state added by _handlePawnPromotionLogic was for the state *before* this promotion choice.
+    // That is correct.
+
+    return state.copyWith(
+      board: newBoard,
+      currentPlayer: nextPlayer, // Now switch player
+      moveHistory: List.from(state.moveHistory)..add(lastMove),
+      specialMoveMessage: message,
+      lastMove: lastMove,
+      isCheck: isCheck,
+      isCheckmate: isCheckmate,
+      isStalemate: isStalemate,
+      isPendingPromotion: false, // Promotion is complete
+      promotionPosition: null,
+      currentMoveNumber: state.currentMoveNumber + 1, // Increment move number
+      selectedPosition: null,
+      validMoves: [],
+      // undoStates and redoStates are already handled by _handlePawnPromotionLogic
+    );
+  }
+
+  GameState handleMove(GameState state, Position from, Position to) {
+    // This check is similar to ChessBloc._onMovePiece
+    // It assumes validMoves have been pre-calculated and set in the state if needed by UI,
+    // or that the move is programmatically determined to be valid.
+    // For direct calls, the caller is responsible for ensuring 'to' is a valid target.
+    // Here we re-fetch valid moves for safety if not already present for the selected piece.
+    
+    final List<Position> currentValidMoves = (state.selectedPosition == from)
+        ? state.validMoves
+        : getValidMovesForPiece(state, from);
+
+    final isValidMove = currentValidMoves.any(
+      (pos) => pos.row == to.row && pos.col == to.col
+    );
+
+    if (!isValidMove) {
+      // Optionally, return state with an error message or just the unchanged state
+      return state.copyWith(specialMoveMessage: "Invalid move selected.");
+    }
+
+    final movingPiece = state.board[from.row][from.col]!;
+    final capturedPiece = state.board[to.row][to.col]; // Might be null
+    
+    // Create a mutable copy of the board
+    final newBoard = List<List<ChessPiece?>>.from(
+      state.board.map((row) => List<ChessPiece?>.from(row)),
+    );
+
+    if (_isCastlingMove(movingPiece, from, to)) {
+      return _handleCastlingLogic(state, movingPiece, from, to, newBoard);
+    }
+
+    if (_isEnPassantMove(state, movingPiece, from, to, capturedPiece)) {
+      return _handleEnPassantLogic(state, movingPiece, from, to, newBoard);
+    }
+
+    if (_isPawnPromotion(movingPiece, to)) {
+      return _handlePawnPromotionLogic(state, movingPiece, from, to, newBoard);
+    }
+
+    return _handleRegularMoveLogic(state, movingPiece, capturedPiece, from, to, newBoard);
+  }
+}

--- a/lib/utils/chess_rules.dart
+++ b/lib/utils/chess_rules.dart
@@ -50,29 +50,39 @@ class ChessRules {
     }
 
     // 检查每个移动是否会导致自己被将军
+    return _filterLegalMoves(board, position, piece, possibleMoves, lastPawnDoubleMoved);
+  }
+
+  static List<Position> _filterLegalMoves(
+    List<List<ChessPiece?>> board,
+    Position piecePosition,
+    ChessPiece piece,
+    List<Position> possibleMoves,
+    Position? lastPawnDoubleMoved,
+  ) {
     List<Position> legalMoves = [];
     for (final move in possibleMoves) {
       final newBoard = List<List<ChessPiece?>>.from(
         board.map((row) => List<ChessPiece?>.from(row))
       );
 
-      // 如果是吃过路兵，需要移除被吃的兵
+      // Simulate the move
+      newBoard[move.row][move.col] = piece;
+      newBoard[piecePosition.row][piecePosition.col] = null;
+
+      // If it's an en passant capture, remove the captured pawn
       if (piece.type == PieceType.pawn &&
           lastPawnDoubleMoved != null &&
           move.col == lastPawnDoubleMoved.col &&
-          (position.col - lastPawnDoubleMoved.col).abs() == 1) {
+          move.row == (piece.color == PieceColor.white ? lastPawnDoubleMoved.row - 1 : lastPawnDoubleMoved.row + 1) &&
+          (piecePosition.col - lastPawnDoubleMoved.col).abs() == 1) {
         newBoard[lastPawnDoubleMoved.row][lastPawnDoubleMoved.col] = null;
       }
-
-      newBoard[move.row][move.col] = newBoard[position.row][position.col];
-      newBoard[position.row][position.col] = null;
-
-      // 如果移动后自己不会被将军，这是一个合法移动
+      
       if (!isInCheck(newBoard, piece.color)) {
         legalMoves.add(move);
       }
     }
-
     return legalMoves;
   }
 
@@ -85,23 +95,45 @@ class ChessRules {
     int? currentMoveNumber,
   }) {
     List<Position> moves = [];
+    _addPawnForwardMoves(board, position, color, moves);
+    _addPawnCaptureMoves(board, position, color, moves);
+    _addEnPassantMoves(board, position, color, lastPawnDoubleMoved, lastPawnDoubleMovedNumber, currentMoveNumber, moves);
+    return moves;
+  }
+
+  static void _addPawnForwardMoves(
+    List<List<ChessPiece?>> board,
+    Position position,
+    PieceColor color,
+    List<Position> moves,
+  ) {
     final direction = color == PieceColor.white ? -1 : 1;
     final startRow = color == PieceColor.white ? 6 : 1;
 
-    // 前进一步
-    if (_isValidPosition(position.row + direction, position.col) &&
-        board[position.row + direction][position.col] == null) {
-      moves.add(Position(row: position.row + direction, col: position.col));
+    // Forward one step
+    final oneStepForwardRow = position.row + direction;
+    if (_isValidPosition(oneStepForwardRow, position.col) &&
+        board[oneStepForwardRow][position.col] == null) {
+      moves.add(Position(row: oneStepForwardRow, col: position.col));
 
-      // 如果在起始位置，可以前进两步
-      if (position.row == startRow &&
-          _isValidPosition(position.row + 2 * direction, position.col) &&
-          board[position.row + 2 * direction][position.col] == null) {
-        moves.add(Position(row: position.row + 2 * direction, col: position.col));
+      // Forward two steps from start
+      if (position.row == startRow) {
+        final twoStepsForwardRow = position.row + 2 * direction;
+        if (_isValidPosition(twoStepsForwardRow, position.col) &&
+            board[twoStepsForwardRow][position.col] == null) {
+          moves.add(Position(row: twoStepsForwardRow, col: position.col));
+        }
       }
     }
-
-    // 常规吃子移动
+  }
+  
+  static void _addPawnCaptureMoves(
+    List<List<ChessPiece?>> board,
+    Position position,
+    PieceColor color,
+    List<Position> moves,
+  ) {
+    final direction = color == PieceColor.white ? -1 : 1;
     for (final colOffset in [-1, 1]) {
       final newRow = position.row + direction;
       final newCol = position.col + colOffset;
@@ -112,21 +144,40 @@ class ChessRules {
         }
       }
     }
+  }
 
-    // 吃过路兵
-    if (lastPawnDoubleMoved != null &&
-        lastPawnDoubleMovedNumber == currentMoveNumber! - 1 &&
-        position.row == (color == PieceColor.white ? 3 : 4) &&
-        (position.col - lastPawnDoubleMoved.col).abs() == 1 &&
-        board[lastPawnDoubleMoved.row][lastPawnDoubleMoved.col]?.type == PieceType.pawn &&
-        board[lastPawnDoubleMoved.row][lastPawnDoubleMoved.col]?.color != color) {
-      moves.add(Position(
-        row: position.row + direction,
-        col: lastPawnDoubleMoved.col,
-      ));
+  static void _addEnPassantMoves(
+    List<List<ChessPiece?>> board,
+    Position position,
+    PieceColor color,
+    Position? lastPawnDoubleMoved,
+    int? lastPawnDoubleMovedNumber,
+    int? currentMoveNumber,
+    List<Position> moves,
+  ) {
+    if (lastPawnDoubleMoved == null || lastPawnDoubleMovedNumber == null || currentMoveNumber == null) {
+      return;
+    }
+    if (lastPawnDoubleMovedNumber != currentMoveNumber - 1) {
+      return;
     }
 
-    return moves;
+    final direction = color == PieceColor.white ? -1 : 1;
+    final enPassantRow = color == PieceColor.white ? 3 : 4; // Row where the current pawn must be
+
+    if (position.row == enPassantRow &&
+        (position.col - lastPawnDoubleMoved.col).abs() == 1 &&
+        lastPawnDoubleMoved.row == enPassantRow) { // Opponent's pawn must be on the same rank
+        // Target square for en passant capture
+        final targetRow = position.row + direction;
+        final targetCol = lastPawnDoubleMoved.col;
+        
+        // Check if the opponent's piece that double-stepped is actually a pawn and of opponent color
+        final opponentPawn = board[lastPawnDoubleMoved.row][lastPawnDoubleMoved.col];
+        if (opponentPawn != null && opponentPawn.type == PieceType.pawn && opponentPawn.color != color) {
+             moves.add(Position(row: targetRow, col: targetCol));
+        }
+    }
   }
 
   static List<Position> _getRookMoves(
@@ -249,13 +300,23 @@ class ChessRules {
     Map<PieceColor, Map<String, bool>>? hasRookMoved,
   }) {
     List<Position> moves = [];
+    _addStandardKingMoves(board, position, color, moves);
+    _addCastlingMoves(board, position, color, hasKingMoved, hasRookMoved, moves);
+    return moves;
+  }
+
+  static void _addStandardKingMoves(
+    List<List<ChessPiece?>> board,
+    Position position,
+    PieceColor color,
+    List<Position> moves,
+  ) {
     final directions = [
       [-1, -1], [-1, 0], [-1, 1],
       [0, -1],           [0, 1],
       [1, -1],  [1, 0],  [1, 1],
     ];
 
-    // 常规移动
     for (final direction in directions) {
       final newRow = position.row + direction[0];
       final newCol = position.col + direction[1];
@@ -267,32 +328,50 @@ class ChessRules {
         }
       }
     }
+  }
 
-    // 王车易位
-    if (hasKingMoved != null &&
-        hasRookMoved != null &&
-        !hasKingMoved[color]!) {
-      final row = color == PieceColor.white ? 7 : 0;
+  static void _addCastlingMoves(
+    List<List<ChessPiece?>> board,
+    Position position, // King's current position
+    PieceColor color,
+    Map<PieceColor, bool>? hasKingMoved,
+    Map<PieceColor, Map<String, bool>>? hasRookMoved,
+    List<Position> moves,
+  ) {
+    if (hasKingMoved == null || hasRookMoved == null || hasKingMoved[color] == true) {
+      return;
+    }
 
-      // 王翼易位
-      if (!hasRookMoved[color]!['kingside']! &&
-          board[row][5] == null &&
-          board[row][6] == null &&
-          board[row][7]?.type == PieceType.rook) {
-        moves.add(Position(row: row, col: 6));
-      }
+    final kingRow = position.row; // King's current row, should match color's standard row
 
-      // 后翼易位
-      if (!hasRookMoved[color]!['queenside']! &&
-          board[row][1] == null &&
-          board[row][2] == null &&
-          board[row][3] == null &&
-          board[row][0]?.type == PieceType.rook) {
-        moves.add(Position(row: row, col: 2));
+    // Kingside castling
+    if (hasRookMoved[color]?['kingside'] == false &&
+        board[kingRow][position.col + 1] == null &&
+        board[kingRow][position.col + 2] == null &&
+        board[kingRow][position.col + 3]?.type == PieceType.rook &&
+        board[kingRow][position.col + 3]?.color == color) {
+      // Check if squares king moves over are attacked
+      if (!_isSquareAttacked(board, Position(row: kingRow, col: position.col + 1), color) &&
+          !_isSquareAttacked(board, Position(row: kingRow, col: position.col + 2), color) &&
+          !isInCheck(board, color)) { // King not currently in check
+        moves.add(Position(row: kingRow, col: position.col + 2));
       }
     }
 
-    return moves;
+    // Queenside castling
+    if (hasRookMoved[color]?['queenside'] == false &&
+        board[kingRow][position.col - 1] == null &&
+        board[kingRow][position.col - 2] == null &&
+        board[kingRow][position.col - 3] == null &&
+        board[kingRow][position.col - 4]?.type == PieceType.rook &&
+        board[kingRow][position.col - 4]?.color == color) {
+      // Check if squares king moves over are attacked
+      if (!_isSquareAttacked(board, Position(row: kingRow, col: position.col - 1), color) &&
+          !_isSquareAttacked(board, Position(row: kingRow, col: position.col - 2), color) &&
+           !isInCheck(board, color)) { // King not currently in check
+        moves.add(Position(row: kingRow, col: position.col - 2));
+      }
+    }
   }
 
   static bool _isValidPosition(int row, int col) {
@@ -301,32 +380,37 @@ class ChessRules {
 
   // 检查指定颜色的王是否被将军
   static bool isInCheck(List<List<ChessPiece?>> board, PieceColor kingColor) {
-    // 找到王的位置
-    Position? kingPosition;
-    for (int row = 0; row < 8; row++) {
-      for (int col = 0; col < 8; col++) {
-        final piece = board[row][col];
-        if (piece?.type == PieceType.king && piece?.color == kingColor) {
-          kingPosition = Position(row: row, col: col);
-          break;
+    final kingPosition = _findKingPosition(board, kingColor);
+    if (kingPosition == null) return false; // Should not happen in a valid game
+
+    return _isSquareAttacked(board, kingPosition, kingColor);
+  }
+
+  static Position? _findKingPosition(List<List<ChessPiece?>> board, PieceColor kingColor) {
+    for (int r = 0; r < 8; r++) {
+      for (int c = 0; c < 8; c++) {
+        final piece = board[r][c];
+        if (piece != null && piece.type == PieceType.king && piece.color == kingColor) {
+          return Position(row: r, col: c);
         }
       }
-      if (kingPosition != null) break;
     }
+    return null;
+  }
 
-    if (kingPosition == null) return false;
-
-    // 检查对手的所有棋子是否可以攻击到王
-    final opponentColor = kingColor == PieceColor.white ? PieceColor.black : PieceColor.white;
-    for (int row = 0; row < 8; row++) {
-      for (int col = 0; col < 8; col++) {
-        final piece = board[row][col];
-        if (piece?.color == opponentColor) {
-          final moves = getValidMovesWithoutCheckingCheck(
-            board,
-            Position(row: row, col: col),
-          );
-          if (moves.any((pos) => pos.row == kingPosition!.row && pos.col == kingPosition.col)) {
+  static bool _isSquareAttacked(List<List<ChessPiece?>> board, Position square, PieceColor byPlayerColor) {
+    // Check if any piece of the opponent can attack the given square.
+    // Note: byPlayerColor is the color of the player *being attacked* on the square,
+    // so we look for attackers of the opposite color.
+    final attackerColor = byPlayerColor == PieceColor.white ? PieceColor.black : PieceColor.white;
+    for (int r = 0; r < 8; r++) {
+      for (int c = 0; c < 8; c++) {
+        final piece = board[r][c];
+        if (piece != null && piece.color == attackerColor) {
+          // Use getValidMovesWithoutCheckingCheck to see if the attacker can move to the square.
+          // This avoids recursion with isInCheck.
+          final moves = getValidMovesWithoutCheckingCheck(board, Position(row: r, col: c));
+          if (moves.any((move) => move.row == square.row && move.col == square.col)) {
             return true;
           }
         }
@@ -335,6 +419,38 @@ class ChessRules {
     return false;
   }
 
+  static bool _hasAnyLegalMove(
+    List<List<ChessPiece?>> board,
+    PieceColor color,
+    Map<PieceColor, bool> hasKingMoved,
+    Map<PieceColor, Map<String, bool>> hasRookMoved,
+    Map<PieceColor, Position?> lastPawnDoubleMoved, // Full map for both colors
+    Map<PieceColor, int> lastPawnDoubleMovedNumber, // Full map
+    int currentMoveNumber,
+  ) {
+    for (int r = 0; r < 8; r++) {
+      for (int c = 0; c < 8; c++) {
+        final piece = board[r][c];
+        if (piece != null && piece.color == color) {
+          final opponentColor = color == PieceColor.white ? PieceColor.black : PieceColor.white;
+          final moves = getValidMoves(
+            board,
+            Position(row: r, col: c),
+            hasKingMoved: hasKingMoved,
+            hasRookMoved: hasRookMoved,
+            lastPawnDoubleMoved: lastPawnDoubleMoved[opponentColor], // Pass opponent's last double move
+            lastPawnDoubleMovedNumber: lastPawnDoubleMovedNumber[opponentColor], // Pass opponent's number
+            currentMoveNumber: currentMoveNumber,
+          );
+          if (moves.isNotEmpty) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+  
   // 检查指定颜色是否被将死
   static bool isCheckmate(
     List<List<ChessPiece?>> board,
@@ -345,40 +461,8 @@ class ChessRules {
     Map<PieceColor, int> lastPawnDoubleMovedNumber,
     int currentMoveNumber,
   ) {
-    // 如果没有被将军，就不可能被将死
     if (!isInCheck(board, color)) return false;
-
-    // 检查所有己方棋子的所有可能移动
-    for (int row = 0; row < 8; row++) {
-      for (int col = 0; col < 8; col++) {
-        final piece = board[row][col];
-        if (piece?.color == color) {
-          final moves = getValidMoves(
-            board,
-            Position(row: row, col: col),
-            hasKingMoved: hasKingMoved,
-            hasRookMoved: hasRookMoved,
-            lastPawnDoubleMoved: lastPawnDoubleMoved[color == PieceColor.white ? PieceColor.black : PieceColor.white],
-            lastPawnDoubleMovedNumber: lastPawnDoubleMovedNumber[color == PieceColor.white ? PieceColor.black : PieceColor.white],
-            currentMoveNumber: currentMoveNumber,
-          );
-
-          // 对于每个可能的移动，检查是否能解除将军
-          for (final move in moves) {
-            final newBoard = List<List<ChessPiece?>>.from(
-              board.map((row) => List<ChessPiece?>.from(row))
-            );
-            newBoard[move.row][move.col] = newBoard[row][col];
-            newBoard[row][col] = null;
-
-            if (!isInCheck(newBoard, color)) {
-              return false;  // 找到一个可以解除将军的移动，不是将死
-            }
-          }
-        }
-      }
-    }
-    return true;  // 没有找到任何可以解除将军的移动，是将死
+    return !_hasAnyLegalMove(board, color, hasKingMoved, hasRookMoved, lastPawnDoubleMoved, lastPawnDoubleMovedNumber, currentMoveNumber);
   }
 
   // 检查是否是和棋（无子可动）
@@ -391,30 +475,8 @@ class ChessRules {
     Map<PieceColor, int> lastPawnDoubleMovedNumber,
     int currentMoveNumber,
   ) {
-    // 如果被将军，就不是和棋
     if (isInCheck(board, color)) return false;
-
-    // 检查是否有任何合法移动
-    for (int row = 0; row < 8; row++) {
-      for (int col = 0; col < 8; col++) {
-        final piece = board[row][col];
-        if (piece?.color == color) {
-          final moves = getValidMoves(
-            board,
-            Position(row: row, col: col),
-            hasKingMoved: hasKingMoved,
-            hasRookMoved: hasRookMoved,
-            lastPawnDoubleMoved: lastPawnDoubleMoved[color == PieceColor.white ? PieceColor.black : PieceColor.white],
-            lastPawnDoubleMovedNumber: lastPawnDoubleMovedNumber[color == PieceColor.white ? PieceColor.black : PieceColor.white],
-            currentMoveNumber: currentMoveNumber,
-          );
-          if (moves.isNotEmpty) {
-            return false;  // 找到一个合法移动，不是和棋
-          }
-        }
-      }
-    }
-    return true;  // 没有任何合法移动，是和棋
+    return !_hasAnyLegalMove(board, color, hasKingMoved, hasRookMoved, lastPawnDoubleMoved, lastPawnDoubleMovedNumber, currentMoveNumber);
   }
 
   // 获取所有可能的移动，不检查是否会导致自己被将军

--- a/test/chess_rules_test.dart
+++ b/test/chess_rules_test.dart
@@ -3,6 +3,67 @@ import 'package:testflutter/models/chess_models.dart';
 import 'package:testflutter/utils/chess_rules.dart';
 
 void main() {
+  group('Pawn Moves Tests', () {
+    late List<List<ChessPiece?>> board;
+
+    setUp(() {
+      board = List.generate(8, (i) => List.generate(8, (j) => null));
+    });
+
+    test('initial pawn move should allow one or two steps forward', () {
+      // White pawn at e2
+      board[6][4] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white);
+      final moves = ChessRules.getValidMoves(board, const Position(row: 6, col: 4));
+      expect(moves, containsAll([
+        const Position(row: 5, col: 4), // e3
+        const Position(row: 4, col: 4), // e4
+      ]));
+      expect(moves.length, 2);
+
+      // Black pawn at d7
+      board[1][3] = const ChessPiece(type: PieceType.pawn, color: PieceColor.black);
+      final blackMoves = ChessRules.getValidMoves(board, const Position(row: 1, col: 3));
+      expect(blackMoves, containsAll([
+        const Position(row: 2, col: 3), // d6
+        const Position(row: 3, col: 3), // d5
+      ]));
+      expect(blackMoves.length, 2);
+    });
+
+    test('pawn forward move should be blocked by another piece', () {
+      // White pawn at e2, white piece at e3
+      board[6][4] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white);
+      board[5][4] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white); // Blocker
+      final moves = ChessRules.getValidMoves(board, const Position(row: 6, col: 4));
+      expect(moves, isEmpty);
+    });
+    
+    test('pawn capture moves diagonally', () {
+      // White pawn at e4, black pawns at d5 and f5
+      board[4][4] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white);
+      board[3][3] = const ChessPiece(type: PieceType.pawn, color: PieceColor.black); // d5
+      board[3][5] = const ChessPiece(type: PieceType.pawn, color: PieceColor.black); // f5
+      
+      final moves = ChessRules.getValidMoves(board, const Position(row: 4, col: 4));
+      expect(moves, containsAll([
+        const Position(row: 3, col: 3), // Capture d5
+        const Position(row: 3, col: 5), // Capture f5
+      ]));
+      // Should also contain forward move if e5 is empty
+      expect(moves, contains(const Position(row: 3, col: 4))); // e5
+      expect(moves.length, 3);
+    });
+
+    test('pawn should not capture own color piece', () {
+      board[4][4] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white);
+      board[3][3] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white); // Own piece at d5
+      final moves = ChessRules.getValidMoves(board, const Position(row: 4, col: 4));
+      expect(moves.any((m) => m.row == 3 && m.col == 3), isFalse); // Cannot capture d5
+      expect(moves, contains(const Position(row: 3, col: 4))); // Can still move to e5
+    });
+
+  });
+
   group('En Passant Tests', () {
     late List<List<ChessPiece?>> board;
 
@@ -156,6 +217,258 @@ void main() {
         isFalse,
         reason: '不应该允许在双步移动后的第二步吃过路兵',
       );
+    });
+  });
+
+  group('King Moves Tests', () {
+    late List<List<ChessPiece?>> board;
+
+    setUp(() {
+      board = List.generate(8, (i) => List.generate(8, (j) => null));
+    });
+
+    test('standard king moves', () {
+      board[3][3] = const ChessPiece(type: PieceType.king, color: PieceColor.white); // King at d4
+      final moves = ChessRules.getValidMoves(board, const Position(row: 3, col: 3));
+      expect(moves, containsAll([
+        const Position(row: 2, col: 2), const Position(row: 2, col: 3), const Position(row: 2, col: 4),
+        const Position(row: 3, col: 2),                             const Position(row: 3, col: 4),
+        const Position(row: 4, col: 2), const Position(row: 4, col: 3), const Position(row: 4, col: 4),
+      ]));
+      expect(moves.length, 8);
+    });
+
+    test('king moves blocked by own pieces', () {
+      board[3][3] = const ChessPiece(type: PieceType.king, color: PieceColor.white); // King at d4
+      board[2][3] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white); // Own pawn at d3 (blocks forward)
+      final moves = ChessRules.getValidMoves(board, const Position(row: 3, col: 3));
+      expect(moves.length, 7); // Should not contain (2,3)
+      expect(moves.any((m) => m.row == 2 && m.col == 3), isFalse);
+    });
+
+    test('king captures opponent pieces', () {
+      board[3][3] = const ChessPiece(type: PieceType.king, color: PieceColor.white); // King at d4
+      board[2][3] = const ChessPiece(type: PieceType.pawn, color: PieceColor.black); // Opponent pawn at d3
+      final moves = ChessRules.getValidMoves(board, const Position(row: 3, col: 3));
+      expect(moves, contains(const Position(row: 2, col: 3))); // Can capture d3
+      expect(moves.length, 8);
+    });
+
+    group('Castling', () {
+      Map<PieceColor, bool> hasKingMoved = {PieceColor.white: false, PieceColor.black: false};
+      Map<PieceColor, Map<String, bool>> hasRookMoved = {
+        PieceColor.white: {'kingside': false, 'queenside': false},
+        PieceColor.black: {'kingside': false, 'queenside': false},
+      };
+
+      setUp((){
+        // Reset castling flags for each test
+        hasKingMoved = {PieceColor.white: false, PieceColor.black: false};
+        hasRookMoved = {
+          PieceColor.white: {'kingside': false, 'queenside': false},
+          PieceColor.black: {'kingside': false, 'queenside': false},
+        };
+      });
+      
+      test('should allow kingside castling if conditions met', () {
+        board[7][4] = const ChessPiece(type: PieceType.king, color: PieceColor.white); // Ke1
+        board[7][7] = const ChessPiece(type: PieceType.rook, color: PieceColor.white); // Rh1
+        // Path e1-h1 is clear (f1, g1 are null)
+        final moves = ChessRules.getValidMoves(
+          board, const Position(row: 7, col: 4), 
+          hasKingMoved: hasKingMoved, hasRookMoved: hasRookMoved
+        );
+        expect(moves, contains(const Position(row: 7, col: 6))); // Kg1
+      });
+
+      test('should allow queenside castling if conditions met', () {
+        board[7][4] = const ChessPiece(type: PieceType.king, color: PieceColor.white); // Ke1
+        board[7][0] = const ChessPiece(type: PieceType.rook, color: PieceColor.white); // Ra1
+        // Path e1-a1 is clear (b1, c1, d1 are null)
+        final moves = ChessRules.getValidMoves(
+          board, const Position(row: 7, col: 4),
+          hasKingMoved: hasKingMoved, hasRookMoved: hasRookMoved
+        );
+        expect(moves, contains(const Position(row: 7, col: 2))); // Kc1
+      });
+
+      test('should not allow castling if king has moved', () {
+        hasKingMoved[PieceColor.white] = true;
+        board[7][4] = const ChessPiece(type: PieceType.king, color: PieceColor.white);
+        board[7][7] = const ChessPiece(type: PieceType.rook, color: PieceColor.white);
+        final moves = ChessRules.getValidMoves(
+          board, const Position(row: 7, col: 4),
+          hasKingMoved: hasKingMoved, hasRookMoved: hasRookMoved
+        );
+        expect(moves.any((m) => m.col == 6 || m.col == 2), isFalse);
+      });
+
+      test('should not allow kingside castling if kingside rook has moved', () {
+        hasRookMoved[PieceColor.white]?['kingside'] = true;
+        board[7][4] = const ChessPiece(type: PieceType.king, color: PieceColor.white);
+        board[7][7] = const ChessPiece(type: PieceType.rook, color: PieceColor.white);
+        final moves = ChessRules.getValidMoves(
+          board, const Position(row: 7, col: 4),
+          hasKingMoved: hasKingMoved, hasRookMoved: hasRookMoved
+        );
+        expect(moves.any((m) => m.row == 7 && m.col == 6), isFalse);
+      });
+      
+      test('should not allow castling if path is blocked', () {
+        board[7][4] = const ChessPiece(type: PieceType.king, color: PieceColor.white);
+        board[7][7] = const ChessPiece(type: PieceType.rook, color: PieceColor.white);
+        board[7][5] = const ChessPiece(type: PieceType.bishop, color: PieceColor.white); // Bishop on f1
+        final moves = ChessRules.getValidMoves(
+          board, const Position(row: 7, col: 4),
+          hasKingMoved: hasKingMoved, hasRookMoved: hasRookMoved
+        );
+        expect(moves.any((m) => m.row == 7 && m.col == 6), isFalse);
+      });
+
+      test('should not allow castling if king is in check', () {
+        board[7][4] = const ChessPiece(type: PieceType.king, color: PieceColor.white); // Ke1
+        board[7][7] = const ChessPiece(type: PieceType.rook, color: PieceColor.white); // Rh1
+        board[0][4] = const ChessPiece(type: PieceType.rook, color: PieceColor.black); // Black rook on e8, checking Ke1
+        
+        final moves = ChessRules.getValidMoves(
+          board, const Position(row: 7, col: 4),
+          hasKingMoved: hasKingMoved, hasRookMoved: hasRookMoved
+        );
+        // King must move out of check, castling not allowed.
+        expect(moves.any((m) => (m.row == 7 && m.col == 6) || (m.row == 7 && m.col ==2)), isFalse);
+      });
+      
+      test('should not allow castling if king passes through an attacked square', () {
+        board[7][4] = const ChessPiece(type: PieceType.king, color: PieceColor.white); // Ke1
+        board[7][7] = const ChessPiece(type: PieceType.rook, color: PieceColor.white); // Rh1
+        board[0][5] = const ChessPiece(type: PieceType.rook, color: PieceColor.black); // Black rook on f8, attacking f1 (square king passes)
+
+        final moves = ChessRules.getValidMoves(
+          board, const Position(row: 7, col: 4),
+          hasKingMoved: hasKingMoved, hasRookMoved: hasRookMoved
+        );
+        expect(moves.any((m) => m.row == 7 && m.col == 6), isFalse); // Kingside castling should be invalid
+      });
+    });
+  });
+
+  group('Check, Checkmate, and Stalemate Tests', () {
+    late List<List<ChessPiece?>> board;
+    Map<PieceColor, bool> hasKingMoved = {PieceColor.white: false, PieceColor.black: false};
+    Map<PieceColor, Map<String, bool>> hasRookMoved = {
+      PieceColor.white: {'kingside': false, 'queenside': false},
+      PieceColor.black: {'kingside': false, 'queenside': false},
+    };
+    Map<PieceColor, Position?> lastPawnDoubleMoved = {PieceColor.white: null, PieceColor.black: null};
+    Map<PieceColor, int> lastPawnDoubleMovedNumber = {PieceColor.white: -1, PieceColor.black: -1};
+    int currentMoveNumber = 1;
+
+
+    setUp(() {
+      board = List.generate(8, (i) => List.generate(8, (j) => null));
+      // Reset castling and en passant flags for each test, though not all tests use them explicitly.
+      hasKingMoved = {PieceColor.white: false, PieceColor.black: false};
+      hasRookMoved = {
+        PieceColor.white: {'kingside': false, 'queenside': false},
+        PieceColor.black: {'kingside': false, 'queenside': false},
+      };
+      lastPawnDoubleMoved = {PieceColor.white: null, PieceColor.black: null};
+      lastPawnDoubleMovedNumber = {PieceColor.white: -1, PieceColor.black: -1};
+      currentMoveNumber = 1;
+    });
+
+    test('isInCheck - by Queen', () {
+      board[0][4] = const ChessPiece(type: PieceType.king, color: PieceColor.black); // Ke8
+      board[0][3] = const ChessPiece(type: PieceType.queen, color: PieceColor.white); // Qd8 check
+      expect(ChessRules.isInCheck(board, PieceColor.black), isTrue);
+    });
+
+    test('isInCheck - by Rook', () {
+      board[0][4] = const ChessPiece(type: PieceType.king, color: PieceColor.black); // Ke8
+      board[0][0] = const ChessPiece(type: PieceType.rook, color: PieceColor.white); // Ra8 check
+      expect(ChessRules.isInCheck(board, PieceColor.black), isTrue);
+    });
+    
+    test('isInCheck - by Knight', () {
+      board[0][4] = const ChessPiece(type: PieceType.king, color: PieceColor.black); // Ke8
+      board[2][5] = const ChessPiece(type: PieceType.knight, color: PieceColor.white); // Nf6 check
+      expect(ChessRules.isInCheck(board, PieceColor.black), isTrue);
+    });
+
+    test('isNotInCheck - safe king', () {
+      board[0][4] = const ChessPiece(type: PieceType.king, color: PieceColor.black); // Ke8
+      board[7][4] = const ChessPiece(type: PieceType.king, color: PieceColor.white); // Ke1
+      expect(ChessRules.isInCheck(board, PieceColor.black), isFalse);
+      expect(ChessRules.isInCheck(board, PieceColor.white), isFalse);
+    });
+
+    test('isCheckmate - Fool\'s Mate like scenario', () {
+      //   k . . . . . . . (row 0)
+      //   . . . . p . . . (row 1) p at e7
+      //   . . . . . . . . (row 2)
+      //   . . . . . . . . (row 3)
+      //   . . . . . . Q . (row 4) White Q at h4
+      //   . . . . . P . . (row 5) White P at f3
+      //   . . . . . . P . (row 6) White P at g2 -> this should be g4 for mate
+      //   . . . . K . . . (row 7)
+      // Corrected Fool's Mate setup (Black King mated by White Queen)
+      // White: Ke1, Qf3 (to h5), Pg2, Ph2
+      // Black: Ke8, Pf7, Pg7
+      // 1. g4 e5 2. f3?? Qh4#
+      board[7][4] = const ChessPiece(type: PieceType.king, color: PieceColor.white); // Ke1
+      board[6][5] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white); // f2 -> f3 (after black e5)
+      board[4][6] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white); // g2 -> g4
+      
+      board[0][4] = const ChessPiece(type: PieceType.king, color: PieceColor.black); // Ke8
+      // board[1][4] = ChessPiece(type: PieceType.pawn, color: PieceColor.black); // Pe7 -> e5
+      board[4][7] = const ChessPiece(type: PieceType.queen, color: PieceColor.white); // Qh4 (White Queen delivering mate)
+      
+      // Set current player to Black, who is checkmated
+      expect(ChessRules.isCheckmate(board, PieceColor.black, hasKingMoved, hasRookMoved, lastPawnDoubleMoved, lastPawnDoubleMovedNumber, currentMoveNumber), isTrue);
+    });
+    
+    test('isCheckmate - Back Rank Mate', () {
+      // White King g1, Pawns f2,g2,h2. Black Rook d1. Black King h8.
+      board[7][6] = const ChessPiece(type: PieceType.king, color: PieceColor.white);   // Kg1
+      board[6][5] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white);   // Pf2
+      board[6][6] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white);   // Pg2
+      board[6][7] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white);   // Ph2
+      board[0][3] = const ChessPiece(type: PieceType.rook, color: PieceColor.black);   // Black Rook at d8 (moves to d1)
+      board[0][7] = const ChessPiece(type: PieceType.king, color: PieceColor.black);   // Kh8
+
+      // Simulate rook moving to d1 to deliver mate
+      board[7][3] = board[0][3]; // Rook moves to d1
+      board[0][3] = null;
+
+      expect(ChessRules.isCheckmate(board, PieceColor.white, hasKingMoved, hasRookMoved, lastPawnDoubleMoved, lastPawnDoubleMovedNumber, currentMoveNumber), isTrue);
+    });
+
+    test('isNotCheckmate - check but can escape', () {
+      board[0][4] = const ChessPiece(type: PieceType.king, color: PieceColor.black); // Ke8
+      board[0][3] = const ChessPiece(type: PieceType.queen, color: PieceColor.white); // Qd8 check
+      // Black king can move to f8 (0,5) or d7 (1,3) if e7 is not blocked
+      expect(ChessRules.isCheckmate(board, PieceColor.black, hasKingMoved, hasRookMoved, lastPawnDoubleMoved, lastPawnDoubleMovedNumber, currentMoveNumber), isFalse);
+    });
+
+    test('isStalemate - King trapped, no check, no legal moves', () {
+      // White King at a1, White Pawns at a2, b2. Black Queen at c2.
+      board[7][0] = const ChessPiece(type: PieceType.king, color: PieceColor.white);   // Ka1
+      board[6][0] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white);   // Pa2
+      board[6][1] = const ChessPiece(type: PieceType.pawn, color: PieceColor.white);   // Pb2
+      board[5][2] = const ChessPiece(type: PieceType.queen, color: PieceColor.black); // Black Qc2
+      board[0][7] = const ChessPiece(type: PieceType.king, color: PieceColor.black);   // Kh8 (opponent king)
+
+      // It's White's turn, White is not in check, but has no legal moves.
+      expect(ChessRules.isStalemate(board, PieceColor.white, hasKingMoved, hasRookMoved, lastPawnDoubleMoved, lastPawnDoubleMovedNumber, currentMoveNumber), isTrue);
+    });
+    
+    test('isNotStalemate - legal moves exist', () {
+      board[7][0] = const ChessPiece(type: PieceType.king, color: PieceColor.white);   // Ka1
+      // Queen not trapping, e.g. at h2
+      board[6][7] = const ChessPiece(type: PieceType.queen, color: PieceColor.black); // Qh2
+      board[0][7] = const ChessPiece(type: PieceType.king, color: PieceColor.black);   // Kh8
+      // White king can move to b1
+      expect(ChessRules.isStalemate(board, PieceColor.white, hasKingMoved, hasRookMoved, lastPawnDoubleMoved, lastPawnDoubleMovedNumber, currentMoveNumber), isFalse);
     });
   });
 } 

--- a/test/game_logic_service_test.dart
+++ b/test/game_logic_service_test.dart
@@ -1,0 +1,700 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:chess_vectors_flutter/chess_vectors_flutter.dart'; // May not be needed directly, but good for context
+import 'package:testflutter/models/chess_models.dart';
+import 'package:testflutter/services/game_logic_service.dart';
+import 'package:testflutter/utils/chess_rules.dart'; // May be needed for some setups or direct rule checks
+
+void main() {
+  late GameLogicService gameLogicService;
+
+  setUp(() {
+    gameLogicService = GameLogicService();
+  });
+
+  group('GameLogicService Tests', () {
+    // --- applyMove Tests ---
+    group('applyMove', () {
+      test('should correctly move a pawn one step forward', () {
+        GameState initialState = GameState.initial();
+        // Example: White pawn from e2 to e3 (assuming e2 is (6,4) and e3 is (5,4) in 0-indexed)
+        final from = Position(row: 6, col: 4);
+        final to = Position(row: 5, col: 4);
+        final piece = initialState.board[from.row][from.col]!;
+        
+        final move = ChessMove(from: from, to: to, piece: piece);
+        GameState newState = gameLogicService.applyMove(initialState, move);
+
+        expect(newState.board[to.row][to.col], equals(piece));
+        expect(newState.board[from.row][from.col], isNull);
+        expect(newState.currentPlayer, PieceColor.black);
+        expect(newState.moveHistory.last, equals(move));
+      });
+
+      test('should correctly move a pawn two steps forward initially', () {
+        GameState initialState = GameState.initial();
+        final from = Position(row: 6, col: 4); // e2
+        final to = Position(row: 4, col: 4);   // e4
+        final piece = initialState.board[from.row][from.col]!;
+        
+        final move = ChessMove(from: from, to: to, piece: piece);
+        GameState newState = gameLogicService.applyMove(initialState, move);
+
+        expect(newState.board[to.row][to.col], equals(piece));
+        expect(newState.board[from.row][from.col], isNull);
+        expect(newState.currentPlayer, PieceColor.black);
+      });
+      
+      test('should correctly capture a piece', () {
+        GameState initialState = GameState.initial();
+        // White Knight g1 to f3 (capture hypothetical black pawn on f3)
+        // Setup: Place a black pawn on f3 (row 5, col 5)
+        List<List<ChessPiece?>> board = List.from(initialState.board.map((row) => List.from(row)));
+        board[5][5] = const ChessPiece(type: PieceType.pawn, color: PieceColor.black);
+        initialState = initialState.copyWith(board: board);
+
+        final from = Position(row: 7, col: 6); // g1
+        final to = Position(row: 5, col: 5);   // f3
+        final knight = initialState.board[from.row][from.col]!;
+        final capturedPawn = initialState.board[to.row][to.col]!;
+        
+        final move = ChessMove(from: from, to: to, piece: knight, capturedPiece: capturedPawn);
+        GameState newState = gameLogicService.applyMove(initialState, move);
+
+        expect(newState.board[to.row][to.col]?.type, equals(PieceType.knight));
+        expect(newState.board[to.row][to.col]?.color, equals(PieceColor.white));
+        expect(newState.board[from.row][from.col], isNull);
+        expect(newState.currentPlayer, PieceColor.black);
+        expect(newState.moveHistory.last.capturedPiece, equals(capturedPawn));
+      });
+
+      test('applyMove should update board for kingside castling', () {
+        GameState initialState = GameState.initial();
+        // Simulate a state where white kingside castling is possible
+        // Clear e1-g1 path: board[7][5] (f1), board[7][6] (g1) are null
+        List<List<ChessPiece?>> board = List.from(initialState.board.map((row) => List.from(row)));
+        board[7][5] = null; // Clear f1
+        board[7][6] = null; // Clear g1
+        initialState = initialState.copyWith(board: board);
+
+        final king = initialState.board[7][4]!; // King at e1
+        final move = ChessMove(
+          from: Position(row: 7, col: 4), // e1
+          to: Position(row: 7, col: 6),   // g1 (king's destination)
+          piece: king,
+          isCastling: true,
+        );
+        GameState newState = gameLogicService.applyMove(initialState, move);
+
+        expect(newState.board[7][6]?.type, PieceType.king); // King at g1
+        expect(newState.board[7][5]?.type, PieceType.rook); // Rook at f1
+        expect(newState.board[7][4], isNull); // e1 empty
+        expect(newState.board[7][7], isNull); // h1 empty (original rook pos)
+      });
+
+      test('applyMove should update board for queenside castling', () {
+        GameState initialState = GameState.initial();
+        // Simulate a state where white queenside castling is possible
+        List<List<ChessPiece?>> board = List.from(initialState.board.map((row) => List.from(row)));
+        board[7][1] = null; // Clear b1
+        board[7][2] = null; // Clear c1
+        board[7][3] = null; // Clear d1
+        initialState = initialState.copyWith(board: board);
+        
+        final king = initialState.board[7][4]!; // King at e1
+        final move = ChessMove(
+          from: Position(row: 7, col: 4), // e1
+          to: Position(row: 7, col: 2),   // c1 (king's destination)
+          piece: king,
+          isCastling: true,
+        );
+        GameState newState = gameLogicService.applyMove(initialState, move);
+
+        expect(newState.board[7][2]?.type, PieceType.king); // King at c1
+        expect(newState.board[7][3]?.type, PieceType.rook); // Rook at d1
+        expect(newState.board[7][4], isNull); // e1 empty
+        expect(newState.board[7][0], isNull); // a1 empty (original rook pos)
+      });
+      
+      test('applyMove should handle en passant capture board update', () {
+        // Setup: White pawn at e5, Black pawn at d5 (just moved from d7)
+        // White to capture d5 en passant by moving e5 to d6
+        List<List<ChessPiece?>> board = List.generate(8, (_) => List<ChessPiece?>.filled(8, null));
+        final whitePawn = ChessPiece(type: PieceType.pawn, color: PieceColor.white);
+        final blackPawn = ChessPiece(type: PieceType.pawn, color: PieceColor.black);
+        board[3][4] = whitePawn; // White pawn at e5 (row 3, col 4)
+        board[3][3] = blackPawn; // Black pawn at d5 (row 3, col 3) - this is the one to be captured
+
+        GameState initialState = GameState.initial().copyWith(
+          board: board,
+          currentPlayer: PieceColor.white,
+          lastPawnDoubleMoved: {PieceColor.black: Position(row:3, col:3)}, // Black pawn at d5 just double moved
+          lastPawnDoubleMovedNumber: {PieceColor.black: 0}, // Assuming this was move 0 for black
+          currentMoveNumber: 1 // White's current move number
+        );
+        
+        final move = ChessMove(
+          from: Position(row: 3, col: 4), // e5
+          to: Position(row: 2, col: 3),   // d6 (target square for white pawn)
+          piece: whitePawn,
+          capturedPiece: blackPawn, // The pawn at d5 is captured
+          isEnPassant: true,
+        );
+        GameState newState = gameLogicService.applyMove(initialState, move);
+
+        expect(newState.board[2][3], equals(whitePawn)); // White pawn at d6
+        expect(newState.board[3][4], isNull);             // e5 is empty
+        expect(newState.board[3][3], isNull);             // d5 (captured black pawn) is empty
+      });
+
+      test('applyMove should update board for pawn promotion', () {
+        // White pawn at e7, moving to e8, promoting to Queen
+        List<List<ChessPiece?>> board = List.generate(8, (_) => List<ChessPiece?>.filled(8, null));
+        final whitePawn = ChessPiece(type: PieceType.pawn, color: PieceColor.white);
+        board[1][4] = whitePawn; // White pawn at e7 (row 1, col 4)
+        GameState initialState = GameState.initial().copyWith(board: board, currentPlayer: PieceColor.white);
+
+        final move = ChessMove(
+          from: Position(row: 1, col: 4), // e7
+          to: Position(row: 0, col: 4),   // e8
+          piece: whitePawn,
+          isPromotion: true,
+          promotionType: PieceType.queen,
+        );
+        GameState newState = gameLogicService.applyMove(initialState, move);
+        
+        expect(newState.board[0][4]?.type, PieceType.queen);
+        expect(newState.board[0][4]?.color, PieceColor.white);
+        expect(newState.board[1][4], isNull);
+      });
+
+    });
+
+    // --- getValidMovesForPiece Tests ---
+    group('getValidMovesForPiece', () {
+      test('should return empty list for a piece with no valid moves (e.g., blocked pawn)', () {
+        // rnbqkbnr/pppppppp/8/8/8/P7/1PPPPPPP/RNBQKBNR w KQkq - 0 1 (a3 blocks a2 pawn)
+        List<List<ChessPiece?>> board = boardFromFEN('rnbqkbnr/pppppppp/8/8/8/P7/1PPPPPPP/RNBQKBNR w KQkq - 0 1');
+        // Manually place a white pawn at a2, and another white pawn at a3, blocking it.
+        board[6][0] = ChessPiece(type: PieceType.pawn, color: PieceColor.white); // a2
+        board[5][0] = ChessPiece(type: PieceType.pawn, color: PieceColor.white); // a3
+        
+        GameState state = GameState.initial().copyWith(board: board, currentPlayer: PieceColor.white);
+        final moves = gameLogicService.getValidMovesForPiece(state, Position(row: 6, col: 0));
+        expect(moves, isEmpty);
+      });
+
+      test('should return correct initial moves for a pawn', () {
+        GameState state = GameState.initial(); // Standard starting board
+        final moves = gameLogicService.getValidMovesForPiece(state, Position(row: 6, col: 4)); // e2 pawn
+        expect(moves, containsAll([Position(row: 5, col: 4), Position(row: 4, col: 4)])); // e3, e4
+        expect(moves.length, 2);
+      });
+
+      test('should return empty list if not player\'s turn', () {
+        GameState state = GameState.initial().copyWith(currentPlayer: PieceColor.black); // Black's turn
+        final moves = gameLogicService.getValidMovesForPiece(state, Position(row: 6, col: 4)); // White e2 pawn
+        expect(moves, isEmpty);
+      });
+
+      test('should return empty list if game is over (checkmate)', () {
+        GameState state = GameState.initial().copyWith(isCheckmate: true);
+        final moves = gameLogicService.getValidMovesForPiece(state, Position(row: 6, col: 4));
+        expect(moves, isEmpty);
+      });
+      
+      test('should return correct moves for a knight', () {
+        GameState state = GameState.initial();
+        final moves = gameLogicService.getValidMovesForPiece(state, Position(row: 7, col: 6)); // Knight at g1
+        expect(moves, containsAll([Position(row: 5, col: 5), Position(row: 5, col: 7)])); // f3, h3
+        expect(moves.length, 2);
+      });
+
+      test('should include castling moves for king if available', () {
+        // Setup board for castling: clear pieces between king and rook
+        List<List<ChessPiece?>> board = boardFromFEN('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1');
+        board[7][5] = null; // f1
+        board[7][6] = null; // g1
+        board[7][1] = null; // b1
+        board[7][2] = null; // c1
+        board[7][3] = null; // d1
+
+        GameState state = GameState.initial().copyWith(
+          board: board,
+          currentPlayer: PieceColor.white,
+          hasKingMoved: {PieceColor.white: false, PieceColor.black: false},
+          hasRookMoved: {
+            PieceColor.white: {'kingside': false, 'queenside': false},
+            PieceColor.black: {'kingside': false, 'queenside': false}
+          }
+        );
+        final moves = gameLogicService.getValidMovesForPiece(state, Position(row: 7, col: 4)); // King at e1
+        
+        // Standard king moves: d1, d2, e2, f2, f1 (if not attacked)
+        // Castling moves: c1 (col 2), g1 (col 6)
+        // Depending on ChessRules implementation, it might return only direct king moves or also castling pseudo-moves
+        // Assuming ChessRules.getValidMoves includes castling destinations for the king
+        expect(moves, anyOf(
+          contains(Position(row: 7, col: 6)), // Kingside castle to g1
+          contains(Position(row: 7, col: 2))  // Queenside castle to c1
+        ));
+      });
+      
+      test('should include en passant capture if available for a pawn', () {
+        // Setup: White pawn at e5, Black pawn at d5 (just moved from d7)
+        List<List<ChessPiece?>> board = List.generate(8, (_) => List<ChessPiece?>.filled(8, null));
+        board[3][4] = ChessPiece(type: PieceType.pawn, color: PieceColor.white); // White pawn at e5
+        board[3][3] = ChessPiece(type: PieceType.pawn, color: PieceColor.black); // Black pawn at d5
+        
+        GameState state = GameState.initial().copyWith(
+          board: board,
+          currentPlayer: PieceColor.white,
+          lastPawnDoubleMoved: {PieceColor.black: Position(row:3, col:3)},
+          lastPawnDoubleMovedNumber: {PieceColor.black: 0}, // Black's last move number
+          currentMoveNumber: 1 // White's current move number (black just moved)
+        );
+
+        final moves = gameLogicService.getValidMovesForPiece(state, Position(row: 3, col: 4)); // White pawn at e5
+        // Valid moves should include:
+        // - e6 (forward)
+        // - d6 (en passant capture)
+        expect(moves, contains(Position(row: 2, col: 4))); // e6
+        expect(moves, contains(Position(row: 2, col: 3))); // d6 (en passant)
+      });
+
+    });
+
+    // --- handleMove Tests ---
+    group('handleMove', () {
+      test('handleMove for a regular pawn move', () {
+        GameState initialState = GameState.initial();
+        // Select e2 pawn, then move to e4
+        initialState = initialState.copyWith(
+          selectedPosition: Position(row: 6, col: 4),
+          validMoves: [Position(row: 5, col: 4), Position(row: 4, col: 4)] // Assume these are pre-calculated
+        );
+        
+        GameState newState = gameLogicService.handleMove(initialState, Position(row: 6, col: 4), Position(row: 4, col: 4));
+
+        expect(newState.board[4][4]?.type, PieceType.pawn);
+        expect(newState.board[6][4], isNull);
+        expect(newState.currentPlayer, PieceColor.black);
+        expect(newState.lastMove?.from, Position(row: 6, col: 4));
+        expect(newState.lastMove?.to, Position(row: 4, col: 4));
+        expect(newState.lastPawnDoubleMoved[PieceColor.white], Position(row: 4, col: 4));
+      });
+
+      test('handleMove for a knight capture', () {
+        List<List<ChessPiece?>> board = boardFromFEN('rnbqkb1r/pppppppp/5n2/8/8/5N2/PPPPPPPP/RNBQKB1R w KQkq - 2 2'); // Knight on f3, f6
+        // Place a black pawn on g5 for white knight on f3 to capture
+        board[3][6] = ChessPiece(type: PieceType.pawn, color: PieceColor.black); // Black pawn at g5
+        
+        GameState initialState = GameState.initial().copyWith(
+          board: board, 
+          currentPlayer: PieceColor.white,
+          selectedPosition: Position(row: 5, col: 5), // White Knight at f3 (assuming FEN maps f3 to 5,5)
+                                                        // Correcting FEN interpretation to 0-indexed:
+                                                        // f3 is (7-3=4, 5) or (5,5) if board is visually [0..7] top to bottom
+                                                        // Standard array: row 5, col 5 for f3 (assuming RNBQKB1R is row 7)
+                                                        // Let's use standard initial board and place knight and target
+        );
+        
+        // Re-setup for clarity: White Knight on e4, Black pawn on d6
+        board = List.generate(8, (_) => List<ChessPiece?>.filled(8, null));
+        final whiteKnight = ChessPiece(type: PieceType.knight, color: PieceColor.white);
+        final blackPawn = ChessPiece(type: PieceType.pawn, color: PieceColor.black);
+        board[4][4] = whiteKnight; // White knight at e4
+        board[2][3] = blackPawn;   // Black pawn at d6
+
+        initialState = GameState.initial().copyWith(
+            board: board,
+            currentPlayer: PieceColor.white,
+            selectedPosition: Position(row: 4, col: 4), // White knight at e4
+            validMoves: [Position(row:2, col:3)] // Assume d6 is a valid move
+        );
+
+        GameState newState = gameLogicService.handleMove(initialState, Position(row: 4, col: 4), Position(row: 2, col: 3));
+        
+        expect(newState.board[2][3]?.type, PieceType.knight);
+        expect(newState.board[2][3]?.color, PieceColor.white);
+        expect(newState.board[4][4], isNull);
+        expect(newState.lastMove?.capturedPiece, equals(blackPawn));
+      });
+
+      test('handleMove for valid kingside castling', () {
+        List<List<ChessPiece?>> board = boardFromFEN('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1');
+        board[7][5] = null; // f1
+        board[7][6] = null; // g1
+        GameState initialState = GameState.initial().copyWith(
+            board: board,
+            currentPlayer: PieceColor.white,
+            hasKingMoved: {PieceColor.white: false, PieceColor.black: false},
+            hasRookMoved: {PieceColor.white: {'kingside': false, 'queenside': false}, PieceColor.black: {'kingside': false, 'queenside': false}},
+            selectedPosition: Position(row: 7, col: 4), // King at e1
+            validMoves: [Position(row: 7, col: 6)] // Assume g1 is a valid castling move
+        );
+
+        GameState newState = gameLogicService.handleMove(initialState, Position(row: 7, col: 4), Position(row: 7, col: 6));
+
+        expect(newState.board[7][6]?.type, PieceType.king);
+        expect(newState.board[7][5]?.type, PieceType.rook);
+        expect(newState.hasKingMoved[PieceColor.white], isTrue);
+        expect(newState.hasRookMoved[PieceColor.white]?['kingside'], isTrue);
+        expect(newState.lastMove?.isCastling, isTrue);
+      });
+      
+      test('handleMove should set isPendingPromotion for pawn reaching promotion rank', () {
+        // White pawn at e7, to move to e8
+        List<List<ChessPiece?>> board = List.generate(8, (_) => List<ChessPiece?>.filled(8, null));
+        final whitePawn = ChessPiece(type: PieceType.pawn, color: PieceColor.white);
+        board[1][4] = whitePawn; // White pawn at e7 (row 1, col 4)
+        
+        GameState initialState = GameState.initial().copyWith(
+            board: board, 
+            currentPlayer: PieceColor.white,
+            selectedPosition: Position(row: 1, col: 4),
+            validMoves: [Position(row: 0, col: 4)] // e8 is valid
+        );
+
+        GameState newState = gameLogicService.handleMove(initialState, Position(row: 1, col: 4), Position(row: 0, col: 4));
+
+        expect(newState.isPendingPromotion, isTrue);
+        expect(newState.promotionPosition, Position(row: 0, col: 4));
+        expect(newState.board[0][4]?.type, PieceType.pawn); // Still a pawn until promotion is chosen
+        expect(newState.currentPlayer, PieceColor.white); // Current player doesn't change yet
+      });
+
+      test('handleMove should not allow castling if king has moved', () {
+        List<List<ChessPiece?>> board = boardFromFEN('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1');
+        board[7][5] = null; board[7][6] = null; // Clear path for kingside
+        GameState initialState = GameState.initial().copyWith(
+            board: board,
+            currentPlayer: PieceColor.white,
+            hasKingMoved: {PieceColor.white: true, PieceColor.black: false}, // King has moved
+            hasRookMoved: {PieceColor.white: {'kingside': false, 'queenside': false}, PieceColor.black: {'kingside': false, 'queenside': false}},
+            selectedPosition: Position(row: 7, col: 4),
+            // getValidMovesForPiece would return no castling move here.
+            // We simulate that handleMove is called with a castling attempt anyway to test its internal checks.
+            // However, handleMove relies on getValidMovesForPiece for primary validation.
+            // For a pure unit test of handleMove's own logic for castling, it assumes the move is "valid" per validMoves.
+            // If ChessRules.getValidMoves correctly filters this, this test is more about the conditions handleMove itself checks.
+            // The _isCastlingMove in GameLogicService doesn't check hasKingMoved flag directly, it's checked by ChessRules.
+            // So, for handleMove to deny this, the validMoves list fed to it should not contain the castling move.
+            // Let's assume validMoves is correctly empty for castling.
+            validMoves: [Position(row:7, col:5)] // only a non-castling move
+        );
+        
+        // Try to make a castling move that shouldn't be in validMoves.
+        GameState newState = gameLogicService.handleMove(initialState, Position(row: 7, col: 4), Position(row: 7, col: 6));
+        // Expect the state to not change to a castled state, or an error/specific message.
+        // Given current handleMove structure, if (row:7, col:6) is not in validMoves, it returns early.
+        expect(newState.board[7][6]?.type, isNot(PieceType.king)); // King should not be at g1
+        expect(newState.lastMove?.isCastling, isNot(true));
+        // More robust: check if board is unchanged or if a regular move to f1 (if valid) was made.
+        // If (7,6) was not in validMoves, specialMoveMessage "Invalid move selected."
+        expect(newState.specialMoveMessage, equals("Invalid move selected."));
+      });
+      
+      test('handleMove for valid en passant', () {
+        List<List<ChessPiece?>> board = List.generate(8, (_) => List<ChessPiece?>.filled(8, null));
+        final whitePawn = ChessPiece(type: PieceType.pawn, color: PieceColor.white);
+        final blackPawn = ChessPiece(type: PieceType.pawn, color: PieceColor.black);
+        board[3][4] = whitePawn; // White pawn at e5
+        board[3][3] = blackPawn; // Black pawn at d5 (this is the one that just moved from d7)
+
+        GameState initialState = GameState.initial().copyWith(
+          board: board,
+          currentPlayer: PieceColor.white,
+          selectedPosition: Position(row: 3, col: 4), // White pawn at e5
+          lastPawnDoubleMoved: {PieceColor.white: null, PieceColor.black: Position(row: 3, col: 3)},
+          lastPawnDoubleMovedNumber: {PieceColor.white: -1, PieceColor.black: 0}, // Black's move was #0
+          currentMoveNumber: 1, // White is making move #1
+          // ChessRules.getValidMoves should provide (2,3) as a valid en passant move
+          validMoves: [Position(row:2, col:4), Position(row:2, col:3)] 
+        );
+
+        GameState newState = gameLogicService.handleMove(initialState, Position(row: 3, col: 4), Position(row: 2, col: 3)); // e5xd6 e.p.
+
+        expect(newState.board[2][3], whitePawn); // White pawn moved to d6
+        expect(newState.board[3][3], isNull);    // Black pawn at d5 captured
+        expect(newState.board[3][4], isNull);    // Original white pawn square e5 is empty
+        expect(newState.lastMove?.isEnPassant, isTrue);
+        expect(newState.lastMove?.capturedPiece, blackPawn);
+        expect(newState.currentPlayer, PieceColor.black);
+      });
+
+      test('handleMove should not perform en passant if conditions not met (e.g., not immediately after double step)', () {
+        List<List<ChessPiece?>> board = List.generate(8, (_) => List<ChessPiece?>.filled(8, null));
+        final whitePawn = ChessPiece(type: PieceType.pawn, color: PieceColor.white);
+        board[3][4] = whitePawn; // White pawn at e5
+        board[3][3] = ChessPiece(type: PieceType.pawn, color: PieceColor.black); // Black pawn at d5
+        
+        GameState initialState = GameState.initial().copyWith(
+          board: board,
+          currentPlayer: PieceColor.white,
+          selectedPosition: Position(row: 3, col: 4),
+          lastPawnDoubleMoved: {PieceColor.white: null, PieceColor.black: Position(row:3, col:3)},
+          lastPawnDoubleMovedNumber: {PieceColor.white: -1, PieceColor.black: 0}, // Black's double step was move 0
+          currentMoveNumber: 3, // More than 1 move has passed since black's double step
+          validMoves: [Position(row:2, col:4)] // Only e6 is valid, not d6 en passant
+        );
+
+        // Attempt en passant even if not in validMoves (to test internal _isEnPassantMove if it were called directly)
+        // However, handleMove will first check validMoves. If d6 is not there, it won't proceed.
+        GameState newState = gameLogicService.handleMove(initialState, Position(row: 3, col: 4), Position(row: 2, col: 3));
+        
+        // Expect that en passant did not happen. Instead, "Invalid move selected." or regular move if d6 was somehow valid.
+        // Based on validMoves provided, d6 is not valid.
+        expect(newState.specialMoveMessage, equals("Invalid move selected."));
+        expect(newState.board[2][3], isNull); // d6 should be empty
+        expect(newState.board[3][3]?.type, PieceType.pawn); // Black pawn still at d5
+      });
+
+    });
+
+    // --- completePawnPromotion Tests ---
+    group('completePawnPromotion', () {
+      late GameState pendingPromotionState;
+
+      setUp(() {
+        // Setup a state where white pawn is at e8 pending promotion
+        List<List<ChessPiece?>> board = List.generate(8, (_) => List<ChessPiece?>.filled(8, null));
+        final whitePawn = ChessPiece(type: PieceType.pawn, color: PieceColor.white);
+        board[0][4] = whitePawn; // White pawn at e8 (after moving from e7)
+        
+        pendingPromotionState = GameState.initial().copyWith(
+          board: board,
+          currentPlayer: PieceColor.white, // Player hasn't switched yet in pending state
+          isPendingPromotion: true,
+          promotionPosition: Position(row: 0, col: 4),
+          lastMove: ChessMove( // The move that led to promotion
+            from: Position(row: 1, col: 4), 
+            to: Position(row: 0, col: 4), 
+            piece: whitePawn, // piece is the pawn before promotion
+            isPromotion: true
+          ),
+          currentMoveNumber: 5 // Example move number
+        );
+      });
+
+      test('should promote pawn to Queen and update state correctly', () {
+        GameState newState = gameLogicService.completePawnPromotion(pendingPromotionState, PieceType.queen);
+
+        expect(newState.board[0][4]?.type, PieceType.queen);
+        expect(newState.board[0][4]?.color, PieceColor.white);
+        expect(newState.isPendingPromotion, isFalse);
+        expect(newState.promotionPosition, isNull);
+        expect(newState.currentPlayer, PieceColor.black); // Player should switch
+        expect(newState.lastMove?.promotionType, PieceType.queen);
+        expect(newState.lastMove?.piece.type, PieceType.queen); // lastMove.piece should be the promoted piece
+        expect(newState.moveHistory.last.promotionType, PieceType.queen);
+        expect(newState.currentMoveNumber, equals(pendingPromotionState.currentMoveNumber + 1));
+      });
+
+      test('should promote pawn to Rook', () {
+        GameState newState = gameLogicService.completePawnPromotion(pendingPromotionState, PieceType.rook);
+        expect(newState.board[0][4]?.type, PieceType.rook);
+        expect(newState.lastMove?.promotionType, PieceType.rook);
+      });
+
+      test('should promote pawn to Bishop', () {
+        GameState newState = gameLogicService.completePawnPromotion(pendingPromotionState, PieceType.bishop);
+        expect(newState.board[0][4]?.type, PieceType.bishop);
+        expect(newState.lastMove?.promotionType, PieceType.bishop);
+      });
+
+      test('should promote pawn to Knight', () {
+        GameState newState = gameLogicService.completePawnPromotion(pendingPromotionState, PieceType.knight);
+        expect(newState.board[0][4]?.type, PieceType.knight);
+        expect(newState.lastMove?.promotionType, PieceType.knight);
+      });
+
+      test('should clear isPendingPromotion and promotionPosition after promotion', () {
+        GameState newState = gameLogicService.completePawnPromotion(pendingPromotionState, PieceType.queen);
+        expect(newState.isPendingPromotion, isFalse);
+        expect(newState.promotionPosition, isNull);
+      });
+      
+      test('should add the completed promotion move to history', () {
+        final initialHistoryLength = pendingPromotionState.moveHistory.length;
+        GameState newState = gameLogicService.completePawnPromotion(pendingPromotionState, PieceType.queen);
+        expect(newState.moveHistory.length, initialHistoryLength + 1);
+        expect(newState.moveHistory.last.isPromotion, isTrue);
+        expect(newState.moveHistory.last.promotionType, PieceType.queen);
+      });
+    });
+
+    // --- Check/Checkmate/Stalemate Tests (via handleMove) ---
+    group('Game End Conditions (via handleMove)', () {
+      test('should set isCheck to true when a move results in check', () {
+        // Setup: White Queen to deliver check to Black King.
+        // Example: White Queen at d5, Black King at e8. Move Qd5-e6+
+        // Simplified: Board with Q on d1, K on e8. Move Q to d8+.
+        List<List<ChessPiece?>> board = List.generate(8, (_) => List<ChessPiece?>.filled(8, null));
+        board[7][3] = ChessPiece(type: PieceType.queen, color: PieceColor.white); // White Queen at d1
+        board[0][4] = ChessPiece(type: PieceType.king, color: PieceColor.black);  // Black King at e8
+        board[7][4] = ChessPiece(type: PieceType.king, color: PieceColor.white);  // White King at e1 (to make it valid state)
+
+
+        GameState initialState = GameState.initial().copyWith(
+            board: board, 
+            currentPlayer: PieceColor.white,
+            selectedPosition: Position(row: 7, col: 3), // Qd1
+            validMoves: [Position(row:0, col:3)] // Qd8 is a valid move
+        );
+
+        GameState newState = gameLogicService.handleMove(initialState, Position(row: 7, col: 3), Position(row: 0, col: 3)); // Qd1-d8+
+        
+        expect(newState.isCheck, isTrue);
+        expect(newState.board[0][3]?.type, PieceType.queen);
+        expect(newState.currentPlayer, PieceColor.black); // Turn switches to black
+      });
+
+      test('should set isCheckmate to true for a simple checkmate (Fool\'s Mate like)', () {
+        // Simplified Fool's Mate:
+        // 1. f3 e5
+        // 2. g4 Qh4#
+        // Board after 1. f3 e5; 2. g4 ??
+        // White: Pawn f3, g4. King e1.
+        // Black: Pawn e5. Queen d8. King e8.
+        // Black to move Qh4#
+        List<List<ChessPiece?>> board = boardFromFEN("rnb1kbnr/pppp1ppp/8/4p3/6P1/5P2/PPPPP2P/RNBQKBNR b KQkq - 0 2");
+        // FEN after 1.f3 e6 2.g4. Black to play Qh4#
+        // rnb1kbnr/pppp1ppp/8/4p3/6P1/5P2/PPPPP2P/RNBQKBNR b KQkq - 0 2
+        // Actually, let's manually set it up for Qh4#
+        // White: Ke1, Pf2, Pg2
+        // Black: Ke8, Qd8
+        // Scenario: White plays f2-f3, then g2-g4. Black plays e7-e5. Black Queen to h4 is mate.
+        // Board state before Qh4#:
+        // White: Ke1, Pf3, Pg4
+        // Black: Ke8, Pe5, Qd8
+        // RNBQKBNR/PPPP1PPP/8/4P3/6p1/5p2/P1PPP2P/1B1Q1BNR b KQkq - 0 2 (Incorrect FEN)
+        
+        // Manual board setup for Black Qh4#
+        // White pieces: King e1, Pawn f3, Pawn g4
+        // Black pieces: King e8, Queen d8, Pawn e7 (to make e5 later)
+        board = List.generate(8, (_) => List<ChessPiece?>.filled(8, null));
+        board[7][4] = ChessPiece(type: PieceType.king, color: PieceColor.white); // Ke1
+        board[5][5] = ChessPiece(type: PieceType.pawn, color: PieceColor.white); // Pf3 (row 5, col 5)
+        board[4][6] = ChessPiece(type: PieceType.pawn, color: PieceColor.white); // Pg4 (row 4, col 6)
+        
+        board[0][4] = ChessPiece(type: PieceType.king, color: PieceColor.black); // Ke8
+        board[0][3] = ChessPiece(type: PieceType.queen, color: PieceColor.black); // Qd8
+        board[1][4] = ChessPiece(type: PieceType.pawn, color: PieceColor.black); // Pe7
+        
+        GameState initialState = GameState.initial().copyWith(
+          board: board,
+          currentPlayer: PieceColor.black,
+          selectedPosition: Position(row: 0, col: 3), // Black Queen at d8
+          // Valid moves for Queen d8 should include h4 (row 4, col 7)
+          // This requires that ChessRules.getValidMoves is working correctly for this state.
+          // For simplicity, assume it's a valid move.
+          validMoves: [Position(row:4, col:7)] 
+        );
+        
+        // Black plays Qh4#
+        GameState newState = gameLogicService.handleMove(initialState, Position(row: 0, col: 3), Position(row: 4, col: 7));
+        
+        expect(newState.isCheckmate, isTrue);
+        expect(newState.isCheck, isTrue); // Checkmate implies check
+        expect(newState.board[4][7]?.type, PieceType.queen); // Queen at h4
+      });
+
+      test('should set isStalemate to true for a simple stalemate', () {
+        // King in corner, blocked by own pieces, not in check. Attacker controls escape squares.
+        // White: Ka1, Pa2, Pb2. Black: Qc2. White to move.
+        List<List<ChessPiece?>> board = List.generate(8, (_) => List<ChessPiece?>.filled(8, null));
+        board[7][0] = ChessPiece(type: PieceType.king, color: PieceColor.white);   // Ka1
+        board[6][0] = ChessPiece(type: PieceType.pawn, color: PieceColor.white);   // Pa2
+        board[6][1] = ChessPiece(type: PieceType.pawn, color: PieceColor.white);   // Pb2
+        board[5][2] = ChessPiece(type: PieceType.queen, color: PieceColor.black); // Black Qc2 (controls b1, a3)
+        // Need a black king somewhere
+        board[0][7] = ChessPiece(type: PieceType.king, color: PieceColor.black);   // Kh8
+
+
+        GameState initialState = GameState.initial().copyWith(
+          board: board,
+          currentPlayer: PieceColor.white, // White to move
+          selectedPosition: Position(row:7, col:0), // King at a1 selected
+          // Assuming ChessRules will determine no valid moves for Ka1
+          validMoves: [] 
+        );
+        
+        // Simulate an attempt to move, or simply check state if no moves are possible.
+        // If we try to move a piece that has no valid moves, handleMove might return current state or specific message.
+        // The stalemate flag is set based on the *next* player having no legal moves *and* not being in check.
+        // So, this setup is for when it's White's turn, White has no moves, and White is not in check.
+        // GameLogicService's handleMove will update the state, and the check/stalemate conditions are evaluated for the *next* player.
+        // This test might be better framed as: after black's move to Qc2, it's white's turn, and white is stalemated.
+        // Let's adjust: Black just moved to Qc2. It's White's turn.
+        // The state passed to handleMove would be *before* black's move to Qc2.
+        // The test should be: GameState where current player (White) has no legal moves and is not in check.
+        // This is typically determined by ChessRules.isStalemate called by GameLogicService.
+        
+        // For this test, we'll construct a state that IS a stalemate for White.
+        // GameLogicService.handleMove is called when Black makes a move that *results* in this stalemate for White.
+        // So, let's assume Black just moved their Queen to c2.
+        // The state *before* Black's move:
+        List<List<ChessPiece?>> boardBeforeBlackMove = List.generate(8, (_) => List<ChessPiece?>.filled(8, null));
+        boardBeforeBlackMove[7][0] = ChessPiece(type: PieceType.king, color: PieceColor.white);   // Ka1
+        boardBeforeBlackMove[6][0] = ChessPiece(type: PieceType.pawn, color: PieceColor.white);   // Pa2
+        boardBeforeBlackMove[6][1] = ChessPiece(type: PieceType.pawn, color: PieceColor.white);   // Pb2
+        boardBeforeBlackMove[0][7] = ChessPiece(type: PieceType.king, color: PieceColor.black);   // Kh8
+        boardBeforeBlackMove[0][2] = ChessPiece(type: PieceType.queen, color: PieceColor.black); // Black Qc7 (example)
+
+        GameState stateBeforeBlackMakesStalematingMove = GameState.initial().copyWith(
+            board: boardBeforeBlackMove,
+            currentPlayer: PieceColor.black, // Black to move to c2
+            selectedPosition: Position(row:0, col:2), // Qc7
+            validMoves: [Position(row:5, col:2)] // Qc2 is valid
+        );
+        
+        GameState newStateAfterBlackMoves = gameLogicService.handleMove(stateBeforeBlackMakesStalematingMove, Position(row:0, col:2), Position(row:5, col:2));
+
+        // Now, newStateAfterBlackMoves is the state where it's White's turn.
+        // We expect isStalemate to be true because White (king at a1) has no legal moves and is not in check.
+        expect(newStateAfterBlackMoves.isStalemate, isTrue);
+        expect(newStateAfterBlackMoves.isCheck, isFalse); // Important for stalemate
+        expect(newStateAfterBlackMoves.currentPlayer, PieceColor.white); // It's white's turn
+      });
+    });
+  });
+}
+
+// Helper to create a board from a string representation (optional, but useful)
+// Example: 
+// rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
+// For simplicity, we might manually construct boards in tests or use GameState.initial()
+// and apply a series of moves.
+List<List<ChessPiece?>> boardFromFEN(String fen) {
+  // Basic FEN parsing for board state - can be expanded
+  final parts = fen.split(' ');
+  final boardRows = parts[0].split('/');
+  final newBoard = List.generate(8, (_) => List<ChessPiece?>.filled(8, null));
+
+  for (int r = 0; r < 8; r++) {
+    int c = 0;
+    for (int i = 0; i < boardRows[r].length; i++) {
+      final char = boardRows[r][i];
+      if (int.tryParse(char) != null) {
+        c += int.parse(char);
+      } else {
+        newBoard[r][c] = _pieceFromChar(char);
+        c++;
+      }
+    }
+  }
+  return newBoard;
+}
+
+ChessPiece? _pieceFromChar(String char) {
+  PieceColor color = char.toUpperCase() == char ? PieceColor.white : PieceColor.black;
+  switch (char.toLowerCase()) {
+    case 'p': return ChessPiece(type: PieceType.pawn, color: color);
+    case 'r': return ChessPiece(type: PieceType.rook, color: color);
+    case 'n': return ChessPiece(type: PieceType.knight, color: color);
+    case 'b': return ChessPiece(type: PieceType.bishop, color: color);
+    case 'q': return ChessPiece(type: PieceType.queen, color: color);
+    case 'k': return ChessPiece(type: PieceType.king, color: color);
+    default: return null;
+  }
+}


### PR DESCRIPTION
This commit introduces a major refactoring of the chess game logic:

- **Introduced `GameLogicService`:** A new service (`lib/services/game_logic_service.dart`) now encapsulates core game logic, including move execution, valid move calculation, special move handling (castling, en passant, pawn promotion), and check/checkmate/stalemate detection.

- **Refactored `ChessBloc`:** `ChessBloc` now delegates all complex game logic operations to `GameLogicService`. This significantly simplifies the BLoC, making it primarily responsible for managing game state transitions and event orchestration. Redundant helper methods related to game rules were removed from the BLoC.

- **Refactored `ChessRules`:** `ChessRules` (`lib/utils/chess_rules.dart`) has been streamlined to be a collection of pure, static utility functions for chess rule calculations. Complex methods were broken down into smaller, more focused helpers, improving clarity and testability. Logic already covered by `GameLogicService` was removed.

- **Improved UI/Logic Separation:** Pawn promotion UI is now driven by state changes in `GameState` (managed by `ChessBloc` and `GameLogicService`), rather than being handled directly in widget tap handlers.

- **Added Comprehensive Unit Tests:**
    - New unit tests were created for `GameLogicService` (`test/game_logic_service_test.dart`), covering various move scenarios, special moves, and game end conditions.
    - Existing tests for `ChessRules` (`test/chess_rules_test.dart`) were reviewed and significantly enhanced to cover its refactored structure, including detailed tests for castling rules, check, checkmate, and stalemate conditions.

This refactoring improves the overall architecture by promoting better separation of concerns, enhancing code clarity and maintainability, and increasing test coverage for the core game mechanics.